### PR TITLE
feat: generate typed field enum with zero-copy decode for protobuf messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,6 @@ name = "tacky"
 version = "0.2.0"
 dependencies = [
  "bytes",
- "prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ bytes = "1"
 
 
 [dev-dependencies]
-prost = "0.12"

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -255,6 +255,10 @@ pub enum DecodeError {
         actual: WireType,
     },
     InvalidUtf8,
+    InvalidEnumValue {
+        field: &'static str,
+        value: i32,
+    },
 }
 
 impl std::fmt::Display for DecodeError {
@@ -271,6 +275,9 @@ impl std::fmt::Display for DecodeError {
                 "wire type mismatch for field \"{field}\": expected {expected:?}, got {actual:?}"
             ),
             DecodeError::InvalidUtf8 => f.write_str("invalid UTF-8 in string field"),
+            DecodeError::InvalidEnumValue { field, value } => {
+                write!(f, "invalid enum value {value} for field \"{field}\"")
+            }
         }
     }
 }
@@ -407,6 +414,16 @@ impl<'a> PackedVarints<'a> {
     }
     pub fn bools(self) -> impl Iterator<Item = Result<bool, DecodeError>> + 'a {
         self.map(|r| r.map(|v| v != 0))
+    }
+    pub fn enums<E: TryFrom<i32>>(self) -> impl Iterator<Item = Result<E, DecodeError>> + 'a {
+        self.map(|r| {
+            r.and_then(|v| {
+                E::try_from(v as i32).map_err(|_| DecodeError::InvalidEnumValue {
+                    field: "<packed>",
+                    value: v as i32,
+                })
+            })
+        })
     }
 }
 

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -380,6 +380,113 @@ pub fn skip_field(wire_type: WireType, buf: &mut &[u8]) -> Result<(), DecodeErro
     Ok(())
 }
 
+// --- Packed iterators ---
+
+/// Zero-copy iterator over packed varint-encoded values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PackedVarints<'a>(pub &'a [u8]);
+
+impl<'a> PackedVarints<'a> {
+    pub fn int32s(self) -> impl Iterator<Item = Result<i32, DecodeError>> + 'a {
+        self.map(|r| r.map(|v| v as i32))
+    }
+    pub fn sint32s(self) -> impl Iterator<Item = Result<i32, DecodeError>> + 'a {
+        self.map(|r| r.map(|v| decode_zigzag32(v as u32)))
+    }
+    pub fn int64s(self) -> impl Iterator<Item = Result<i64, DecodeError>> + 'a {
+        self.map(|r| r.map(|v| v as i64))
+    }
+    pub fn sint64s(self) -> impl Iterator<Item = Result<i64, DecodeError>> + 'a {
+        self.map(|r| r.map(decode_zigzag64))
+    }
+    pub fn uint32s(self) -> impl Iterator<Item = Result<u32, DecodeError>> + 'a {
+        self.map(|r| r.map(|v| v as u32))
+    }
+    pub fn uint64s(self) -> impl Iterator<Item = Result<u64, DecodeError>> + 'a {
+        self.map(|r| r.map(|v| v))
+    }
+    pub fn bools(self) -> impl Iterator<Item = Result<bool, DecodeError>> + 'a {
+        self.map(|r| r.map(|v| v != 0))
+    }
+}
+
+impl<'a> Iterator for PackedVarints<'a> {
+    type Item = Result<u64, DecodeError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.is_empty() {
+            return None;
+        }
+        Some(decode_varint(&mut self.0))
+    }
+}
+
+/// Zero-copy iterator over packed fixed 32-bit values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PackedFixed32s<'a>(pub &'a [u8]);
+
+impl<'a> PackedFixed32s<'a> {
+    pub fn u32s(self) -> impl Iterator<Item = Result<u32, DecodeError>> + 'a {
+        self.map(|r| r.map(u32::from_le_bytes))
+    }
+    pub fn i32s(self) -> impl Iterator<Item = Result<i32, DecodeError>> + 'a {
+        self.map(|r| r.map(i32::from_le_bytes))
+    }
+    pub fn f32s(self) -> impl Iterator<Item = Result<f32, DecodeError>> + 'a {
+        self.map(|r| r.map(f32::from_le_bytes))
+    }
+}
+
+impl<'a> Iterator for PackedFixed32s<'a> {
+    type Item = Result<[u8; 4], DecodeError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.is_empty() {
+            return None;
+        }
+        if self.0.len() < 4 {
+            self.0 = &[];
+            return Some(Err(DecodeError::Truncated));
+        }
+        let (val, rest) = self.0.split_at(4);
+        self.0 = rest;
+        Some(Ok(val.try_into().unwrap()))
+    }
+}
+
+/// Zero-copy iterator over packed fixed 64-bit values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PackedFixed64s<'a>(pub &'a [u8]);
+
+impl<'a> PackedFixed64s<'a> {
+    pub fn u64s(self) -> impl Iterator<Item = Result<u64, DecodeError>> + 'a {
+        self.map(|r| r.map(u64::from_le_bytes))
+    }
+    pub fn i64s(self) -> impl Iterator<Item = Result<i64, DecodeError>> + 'a {
+        self.map(|r| r.map(i64::from_le_bytes))
+    }
+    pub fn f64s(self) -> impl Iterator<Item = Result<f64, DecodeError>> + 'a {
+        self.map(|r| r.map(f64::from_le_bytes))
+    }
+}
+
+impl<'a> Iterator for PackedFixed64s<'a> {
+    type Item = Result<[u8; 8], DecodeError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.is_empty() {
+            return None;
+        }
+        if self.0.len() < 8 {
+            self.0 = &[];
+            return Some(Err(DecodeError::Truncated));
+        }
+        let (val, rest) = self.0.split_at(8);
+        self.0 = rest;
+        Some(Ok(val.try_into().unwrap()))
+    }
+}
+
 // Fixed-width decode functions
 
 #[inline]

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -242,61 +242,61 @@ pub mod decode {
 
     #[inline]
     pub fn decode_fixed32(buf: &mut &[u8]) -> Result<u32, DecodeError> {
-        if buf.len() < 4 {
+        let Some((val, rest)) = buf.split_first_chunk::<4>() else {
             return Err(DecodeError::Truncated);
-        }
-        let val = u32::from_le_bytes(buf[..4].try_into().unwrap());
-        *buf = &buf[4..];
+        };
+        let val = u32::from_le_bytes(*val);
+        *buf = rest;
         Ok(val)
     }
 
     #[inline]
     pub fn decode_sfixed32(buf: &mut &[u8]) -> Result<i32, DecodeError> {
-        if buf.len() < 4 {
+        let Some((val, rest)) = buf.split_first_chunk::<4>() else {
             return Err(DecodeError::Truncated);
-        }
-        let val = i32::from_le_bytes(buf[..4].try_into().unwrap());
-        *buf = &buf[4..];
+        };
+        let val = i32::from_le_bytes(*val);
+        *buf = rest;
         Ok(val)
     }
 
     #[inline]
     pub fn decode_float(buf: &mut &[u8]) -> Result<f32, DecodeError> {
-        if buf.len() < 4 {
+        let Some((val, rest)) = buf.split_first_chunk::<4>() else {
             return Err(DecodeError::Truncated);
-        }
-        let val = f32::from_le_bytes(buf[..4].try_into().unwrap());
-        *buf = &buf[4..];
+        };
+        let val = f32::from_le_bytes(*val);
+        *buf = rest;
         Ok(val)
     }
 
     #[inline]
     pub fn decode_fixed64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
-        if buf.len() < 8 {
+        let Some((val, rest)) = buf.split_first_chunk::<8>() else {
             return Err(DecodeError::Truncated);
-        }
-        let val = u64::from_le_bytes(buf[..8].try_into().unwrap());
-        *buf = &buf[8..];
+        };
+        let val = u64::from_le_bytes(*val);
+        *buf = rest;
         Ok(val)
     }
 
     #[inline]
     pub fn decode_sfixed64(buf: &mut &[u8]) -> Result<i64, DecodeError> {
-        if buf.len() < 8 {
+        let Some((val, rest)) = buf.split_first_chunk::<8>() else {
             return Err(DecodeError::Truncated);
-        }
-        let val = i64::from_le_bytes(buf[..8].try_into().unwrap());
-        *buf = &buf[8..];
+        };
+        let val = i64::from_le_bytes(*val);
+        *buf = rest;
         Ok(val)
     }
 
     #[inline]
     pub fn decode_double(buf: &mut &[u8]) -> Result<f64, DecodeError> {
-        if buf.len() < 8 {
+        let Some((val, rest)) = buf.split_first_chunk::<8>() else {
             return Err(DecodeError::Truncated);
-        }
-        let val = f64::from_le_bytes(buf[..8].try_into().unwrap());
-        *buf = &buf[8..];
+        };
+        let val = f64::from_le_bytes(*val);
+        *buf = rest;
         Ok(val)
     }
 

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -242,3 +242,202 @@ pub enum WireType {
     // EGROUP = 4, //	group end (deprecated)
     I32 = 5, //	fixed32, sfixed32, float
 }
+
+// --- Decode support ---
+
+#[derive(Debug)]
+pub enum DecodeError {
+    Truncated,
+    InvalidWireType(u32),
+    WireTypeMismatch {
+        field: &'static str,
+        expected: WireType,
+        actual: WireType,
+    },
+    InvalidUtf8,
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::Truncated => f.write_str("unexpected end of input"),
+            DecodeError::InvalidWireType(wt) => write!(f, "invalid wire type: {wt}"),
+            DecodeError::WireTypeMismatch {
+                field,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "wire type mismatch for field \"{field}\": expected {expected:?}, got {actual:?}"
+            ),
+            DecodeError::InvalidUtf8 => f.write_str("invalid UTF-8 in string field"),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+impl From<core::str::Utf8Error> for DecodeError {
+    fn from(_: core::str::Utf8Error) -> Self {
+        DecodeError::InvalidUtf8
+    }
+}
+
+#[inline]
+pub const fn decode_zigzag32(n: u32) -> i32 {
+    ((n >> 1) as i32) ^ (-((n & 1) as i32))
+}
+
+#[inline]
+pub const fn decode_zigzag64(n: u64) -> i64 {
+    ((n >> 1) as i64) ^ (-((n & 1) as i64))
+}
+
+#[inline]
+pub fn decode_varint(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let &b = buf.first().ok_or(DecodeError::Truncated)?;
+        *buf = &buf[1..];
+        result |= ((b & 0x7F) as u64) << shift;
+        if b & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(DecodeError::Truncated);
+        }
+    }
+}
+
+#[inline]
+pub fn decode_key(buf: &mut &[u8]) -> Result<(u32, WireType), DecodeError> {
+    let v = decode_varint(buf)?;
+    let tag = (v >> 3) as u32;
+    let wire = (v & 0x07) as u32;
+    let wire_type = match wire {
+        0 => WireType::VARINT,
+        1 => WireType::I64,
+        2 => WireType::LEN,
+        5 => WireType::I32,
+        other => return Err(DecodeError::InvalidWireType(other)),
+    };
+    Ok((tag, wire_type))
+}
+
+/// Decode a length-delimited field, returning a sub-slice of the input.
+#[inline]
+pub fn decode_len<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], DecodeError> {
+    let len = decode_varint(buf)? as usize;
+    if buf.len() < len {
+        return Err(DecodeError::Truncated);
+    }
+    let (data, rest) = buf.split_at(len);
+    *buf = rest;
+    Ok(data)
+}
+
+#[inline]
+pub fn check_wire_type(
+    actual: WireType,
+    expected: WireType,
+    field: &'static str,
+) -> Result<(), DecodeError> {
+    if actual != expected {
+        return Err(DecodeError::WireTypeMismatch {
+            field,
+            expected,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Skip an unknown field value based on wire type.
+#[inline]
+pub fn skip_field(wire_type: WireType, buf: &mut &[u8]) -> Result<(), DecodeError> {
+    match wire_type {
+        WireType::VARINT => {
+            decode_varint(buf)?;
+        }
+        WireType::I64 => {
+            if buf.len() < 8 {
+                return Err(DecodeError::Truncated);
+            }
+            *buf = &buf[8..];
+        }
+        WireType::LEN => {
+            decode_len(buf)?;
+        }
+        WireType::I32 => {
+            if buf.len() < 4 {
+                return Err(DecodeError::Truncated);
+            }
+            *buf = &buf[4..];
+        }
+    }
+    Ok(())
+}
+
+// Fixed-width decode functions
+
+#[inline]
+pub fn decode_i64(buf: &mut &[u8]) -> Result<i64, DecodeError> {
+    if buf.len() < 8 {
+        return Err(DecodeError::Truncated);
+    }
+    let val = i64::from_le_bytes(buf[..8].try_into().unwrap());
+    *buf = &buf[8..];
+    Ok(val)
+}
+
+#[inline]
+pub fn decode_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+    if buf.len() < 8 {
+        return Err(DecodeError::Truncated);
+    }
+    let val = u64::from_le_bytes(buf[..8].try_into().unwrap());
+    *buf = &buf[8..];
+    Ok(val)
+}
+
+#[inline]
+pub fn decode_f64(buf: &mut &[u8]) -> Result<f64, DecodeError> {
+    if buf.len() < 8 {
+        return Err(DecodeError::Truncated);
+    }
+    let val = f64::from_le_bytes(buf[..8].try_into().unwrap());
+    *buf = &buf[8..];
+    Ok(val)
+}
+
+#[inline]
+pub fn decode_i32(buf: &mut &[u8]) -> Result<i32, DecodeError> {
+    if buf.len() < 4 {
+        return Err(DecodeError::Truncated);
+    }
+    let val = i32::from_le_bytes(buf[..4].try_into().unwrap());
+    *buf = &buf[4..];
+    Ok(val)
+}
+
+#[inline]
+pub fn decode_u32(buf: &mut &[u8]) -> Result<u32, DecodeError> {
+    if buf.len() < 4 {
+        return Err(DecodeError::Truncated);
+    }
+    let val = u32::from_le_bytes(buf[..4].try_into().unwrap());
+    *buf = &buf[4..];
+    Ok(val)
+}
+
+#[inline]
+pub fn decode_f32(buf: &mut &[u8]) -> Result<f32, DecodeError> {
+    if buf.len() < 4 {
+        return Err(DecodeError::Truncated);
+    }
+    let val = f32::from_le_bytes(buf[..4].try_into().unwrap());
+    *buf = &buf[4..];
+    Ok(val)
+}

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -34,134 +34,300 @@ pub struct PbString;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct PbBytes;
 
-#[inline]
-pub fn write_varint(mut value: u64, buf: &mut impl BufMut) {
-    loop {
-        if value < 0x80 {
-            buf.put_u8(value as u8);
-            break;
-        } else {
-            buf.put_u8(((value & 0x7F) | 0x80) as u8);
-            value >>= 7;
+pub mod encode {
+    pub use super::*;
+
+    #[inline]
+    pub fn write_varint(mut value: u64, buf: &mut impl BufMut) {
+        loop {
+            if value < 0x80 {
+                buf.put_u8(value as u8);
+                break;
+            } else {
+                buf.put_u8(((value & 0x7F) | 0x80) as u8);
+                value >>= 7;
+            }
         }
+    }
+
+    #[inline]
+    pub const fn encode_zigzag32(n: i32) -> u32 {
+        ((n << 1) ^ (n >> 31)) as u32
+    }
+    #[inline]
+    pub const fn encode_zigzag64(n: i64) -> u64 {
+        ((n << 1) ^ (n >> 63)) as u64
+    }
+    #[inline]
+    pub fn write_double(value: f64, buf: &mut impl BufMut) {
+        buf.put_f64_le(value);
+    }
+    #[inline]
+    pub fn write_float(value: f32, buf: &mut impl BufMut) {
+        buf.put_f32_le(value);
+    }
+    #[inline]
+    pub fn write_int32(value: i32, buf: &mut impl BufMut) {
+        write_varint(value as u64, buf);
+    }
+    #[inline]
+    pub fn write_int64(value: i64, buf: &mut impl BufMut) {
+        write_varint(value as u64, buf);
+    }
+    #[inline]
+    pub fn write_uint32(value: u32, buf: &mut impl BufMut) {
+        write_varint(value as u64, buf);
+    }
+    #[inline]
+    pub fn write_uint64(value: u64, buf: &mut impl BufMut) {
+        write_varint(value, buf);
+    }
+    #[inline]
+    pub fn write_sint32(value: i32, buf: &mut impl BufMut) {
+        write_varint(encode_zigzag32(value) as u64, buf);
+    }
+    #[inline]
+    pub fn write_sint64(value: i64, buf: &mut impl BufMut) {
+        write_varint(encode_zigzag64(value), buf);
+    }
+    #[inline]
+    pub fn write_fixed32(value: u32, buf: &mut impl BufMut) {
+        buf.put_u32_le(value);
+    }
+    #[inline]
+    pub fn write_fixed64(value: u64, buf: &mut impl BufMut) {
+        buf.put_u64_le(value);
+    }
+    #[inline]
+    pub fn write_sfixed32(value: i32, buf: &mut impl BufMut) {
+        buf.put_i32_le(value);
+    }
+    #[inline]
+    pub fn write_sfixed64(value: i64, buf: &mut impl BufMut) {
+        buf.put_i64_le(value);
+    }
+    #[inline]
+    pub fn write_bytes(value: &[u8], buf: &mut impl BufMut) {
+        write_varint(value.len() as u64, buf);
+        buf.put(value);
+    }
+    #[inline]
+    pub fn write_string(value: &str, buf: &mut impl BufMut) {
+        write_bytes(value.as_bytes(), buf);
+    }
+    #[inline]
+    pub fn write_bool(value: bool, buf: &mut impl BufMut) {
+        buf.put_u8(value as u8);
+    }
+}
+pub mod lengths {
+
+    #[inline]
+    pub const fn encoded_len_varint(value: u64) -> usize {
+        // Based on [VarintSize64][1].
+        // [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/io/coded_stream.h#L1301-L1309
+        ((((value | 1).leading_zeros() ^ 63) * 9 + 73) / 64) as usize
+    }
+
+    // lengths
+    #[inline]
+    pub const fn len_of_value<T: Copy>(_: T) -> usize {
+        std::mem::size_of::<T>()
+    }
+    #[inline]
+    pub const fn len_of_string(value: &str) -> usize {
+        encoded_len_varint(value.len() as u64) + value.len()
+    }
+    #[inline]
+    pub const fn len_of_bytes(value: &[u8]) -> usize {
+        encoded_len_varint(value.len() as u64) + value.len()
+    }
+    #[inline]
+    pub const fn len_of_int32(value: i32) -> usize {
+        encoded_len_varint(value as u64)
+    }
+    #[inline]
+    pub const fn len_of_int64(value: i64) -> usize {
+        encoded_len_varint(value as u64)
+    }
+    #[inline]
+    pub const fn len_of_uint32(value: u32) -> usize {
+        encoded_len_varint(value as u64)
+    }
+    #[inline]
+    pub const fn len_of_uint64(value: u64) -> usize {
+        encoded_len_varint(value)
+    }
+    #[inline]
+    pub const fn len_of_sint32(value: i32) -> usize {
+        encoded_len_varint(((value << 1) ^ (value >> 31)) as u64)
+    }
+    #[inline]
+    pub const fn len_of_sint64(value: i64) -> usize {
+        encoded_len_varint(((value << 1) ^ (value >> 63)) as u64)
     }
 }
 
-#[inline]
-pub const fn encoded_len_varint(value: u64) -> usize {
-    // Based on [VarintSize64][1].
-    // [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/io/coded_stream.h#L1301-L1309
-    ((((value | 1).leading_zeros() ^ 63) * 9 + 73) / 64) as usize
+pub mod decode {
+    pub use super::*;
+
+    #[inline]
+    pub const fn decode_zigzag32(n: u32) -> i32 {
+        ((n >> 1) as i32) ^ (-((n & 1) as i32))
+    }
+
+    #[inline]
+    pub const fn decode_zigzag64(n: u64) -> i64 {
+        ((n >> 1) as i64) ^ (-((n & 1) as i64))
+    }
+
+    #[inline]
+    pub fn decode_varint(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+        let mut result: u64 = 0;
+        let mut shift = 0u32;
+        loop {
+            let &b = buf.first().ok_or(DecodeError::Truncated)?;
+            *buf = &buf[1..];
+            result |= ((b & 0x7F) as u64) << shift;
+            if b & 0x80 == 0 {
+                return Ok(result);
+            }
+            shift += 7;
+            if shift >= 64 {
+                return Err(DecodeError::Truncated);
+            }
+        }
+    }
+
+    #[inline]
+    pub fn decode_int32(buf: &mut &[u8]) -> Result<i32, DecodeError> {
+        let v = decode_varint(buf)?;
+        Ok(v as i32)
+    }
+
+    #[inline]
+    pub fn decode_sint32(buf: &mut &[u8]) -> Result<i32, DecodeError> {
+        let v = decode_varint(buf)?;
+        Ok(decode_zigzag32(v as u32))
+    }
+
+    #[inline]
+    pub fn decode_int64(buf: &mut &[u8]) -> Result<i64, DecodeError> {
+        let v = decode_varint(buf)?;
+        Ok(v as i64)
+    }
+
+    #[inline]
+    pub fn decode_sint64(buf: &mut &[u8]) -> Result<i64, DecodeError> {
+        let v = decode_varint(buf)?;
+        Ok(decode_zigzag64(v))
+    }
+
+    #[inline]
+    pub fn decode_uint32(buf: &mut &[u8]) -> Result<u32, DecodeError> {
+        let v = decode_varint(buf)?;
+        Ok(v as u32)
+    }
+
+    #[inline]
+    pub fn decode_uint64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+        decode_varint(buf)
+    }
+
+    #[inline]
+    pub fn decode_bool(buf: &mut &[u8]) -> Result<bool, DecodeError> {
+        let v = decode_varint(buf)?;
+        Ok(v != 0)
+    }
+
+    #[inline]
+    pub fn decode_fixed32(buf: &mut &[u8]) -> Result<u32, DecodeError> {
+        if buf.len() < 4 {
+            return Err(DecodeError::Truncated);
+        }
+        let val = u32::from_le_bytes(buf[..4].try_into().unwrap());
+        *buf = &buf[4..];
+        Ok(val)
+    }
+
+    #[inline]
+    pub fn decode_sfixed32(buf: &mut &[u8]) -> Result<i32, DecodeError> {
+        if buf.len() < 4 {
+            return Err(DecodeError::Truncated);
+        }
+        let val = i32::from_le_bytes(buf[..4].try_into().unwrap());
+        *buf = &buf[4..];
+        Ok(val)
+    }
+
+    #[inline]
+    pub fn decode_float(buf: &mut &[u8]) -> Result<f32, DecodeError> {
+        if buf.len() < 4 {
+            return Err(DecodeError::Truncated);
+        }
+        let val = f32::from_le_bytes(buf[..4].try_into().unwrap());
+        *buf = &buf[4..];
+        Ok(val)
+    }
+
+    #[inline]
+    pub fn decode_fixed64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
+        if buf.len() < 8 {
+            return Err(DecodeError::Truncated);
+        }
+        let val = u64::from_le_bytes(buf[..8].try_into().unwrap());
+        *buf = &buf[8..];
+        Ok(val)
+    }
+
+    #[inline]
+    pub fn decode_sfixed64(buf: &mut &[u8]) -> Result<i64, DecodeError> {
+        if buf.len() < 8 {
+            return Err(DecodeError::Truncated);
+        }
+        let val = i64::from_le_bytes(buf[..8].try_into().unwrap());
+        *buf = &buf[8..];
+        Ok(val)
+    }
+
+    #[inline]
+    pub fn decode_double(buf: &mut &[u8]) -> Result<f64, DecodeError> {
+        if buf.len() < 8 {
+            return Err(DecodeError::Truncated);
+        }
+        let val = f64::from_le_bytes(buf[..8].try_into().unwrap());
+        *buf = &buf[8..];
+        Ok(val)
+    }
+
+    /// Decode a length-delimited field, returning a sub-slice of the input.
+    #[inline]
+    pub fn decode_len<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], DecodeError> {
+        let len = decode_varint(buf)? as usize;
+        if buf.len() < len {
+            return Err(DecodeError::Truncated);
+        }
+        let (data, rest) = buf.split_at(len);
+        *buf = rest;
+        Ok(data)
+    }
+
+    #[inline]
+    pub fn decode_string<'a>(buf: &mut &'a [u8]) -> Result<&'a str, DecodeError> {
+        let bytes = decode_len(buf)?;
+        let s = std::str::from_utf8(bytes)?;
+        Ok(s)
+    }
+
+    #[inline]
+    pub fn decode_bytes<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], DecodeError> {
+        decode_len(buf)
+    }
 }
 
-#[inline]
-pub const fn encode_zigzag32(n: i32) -> u32 {
-    ((n << 1) ^ (n >> 31)) as u32
-}
-#[inline]
-pub const fn encode_zigzag64(n: i64) -> u64 {
-    ((n << 1) ^ (n >> 63)) as u64
-}
-#[inline]
-pub fn write_double(value: f64, buf: &mut impl BufMut) {
-    buf.put_f64_le(value);
-}
-#[inline]
-pub fn write_float(value: f32, buf: &mut impl BufMut) {
-    buf.put_f32_le(value);
-}
-#[inline]
-pub fn write_int32(value: i32, buf: &mut impl BufMut) {
-    write_varint(value as u64, buf);
-}
-#[inline]
-pub fn write_int64(value: i64, buf: &mut impl BufMut) {
-    write_varint(value as u64, buf);
-}
-#[inline]
-pub fn write_uint32(value: u32, buf: &mut impl BufMut) {
-    write_varint(value as u64, buf);
-}
-#[inline]
-pub fn write_uint64(value: u64, buf: &mut impl BufMut) {
-    write_varint(value, buf);
-}
-#[inline]
-pub fn write_sint32(value: i32, buf: &mut impl BufMut) {
-    write_varint(encode_zigzag32(value) as u64, buf);
-}
-#[inline]
-pub fn write_sint64(value: i64, buf: &mut impl BufMut) {
-    write_varint(encode_zigzag64(value), buf);
-}
-#[inline]
-pub fn write_fixed32(value: u32, buf: &mut impl BufMut) {
-    buf.put_u32_le(value);
-}
-#[inline]
-pub fn write_fixed64(value: u64, buf: &mut impl BufMut) {
-    buf.put_u64_le(value);
-}
-#[inline]
-pub fn write_sfixed32(value: i32, buf: &mut impl BufMut) {
-    buf.put_i32_le(value);
-}
-#[inline]
-pub fn write_sfixed64(value: i64, buf: &mut impl BufMut) {
-    buf.put_i64_le(value);
-}
-#[inline]
-pub fn write_bytes(value: &[u8], buf: &mut impl BufMut) {
-    write_varint(value.len() as u64, buf);
-    buf.put(value);
-}
-#[inline]
-pub fn write_string(value: &str, buf: &mut impl BufMut) {
-    write_bytes(value.as_bytes(), buf);
-}
-#[inline]
-pub fn write_bool(value: bool, buf: &mut impl BufMut) {
-    buf.put_u8(value as u8);
-}
-
-// lengths
-#[inline]
-pub const fn len_of_value<T: Copy>(_: T) -> usize {
-    std::mem::size_of::<T>()
-}
-#[inline]
-pub const fn len_of_string(value: &str) -> usize {
-    encoded_len_varint(value.len() as u64) + value.len()
-}
-#[inline]
-pub const fn len_of_bytes(value: &[u8]) -> usize {
-    encoded_len_varint(value.len() as u64) + value.len()
-}
-#[inline]
-pub const fn len_of_int32(value: i32) -> usize {
-    encoded_len_varint(value as u64)
-}
-#[inline]
-pub const fn len_of_int64(value: i64) -> usize {
-    encoded_len_varint(value as u64)
-}
-#[inline]
-pub const fn len_of_uint32(value: u32) -> usize {
-    encoded_len_varint(value as u64)
-}
-#[inline]
-pub const fn len_of_uint64(value: u64) -> usize {
-    encoded_len_varint(value)
-}
-#[inline]
-pub const fn len_of_sint32(value: i32) -> usize {
-    encoded_len_varint(((value << 1) ^ (value >> 31)) as u64)
-}
-#[inline]
-pub const fn len_of_sint64(value: i64) -> usize {
-    encoded_len_varint(((value << 1) ^ (value >> 63)) as u64)
-}
-
+pub use decode::*;
+pub use encode::*;
+pub use lengths::*;
 /// actions on a scalar.
 /// this is already exhaustively implemented as the types in this module contain all protobuf types.
 /// public only because its needed for the codegen crate.
@@ -181,6 +347,7 @@ pub trait ProtobufScalar {
         Self::write_tag(field_nr, buf);
         Self::write_value(value, buf);
     }
+    fn read<'a>(buf: &mut &'a [u8]) -> Result<Self::RustType<'a>, DecodeError>;
     /// len on the wire, tag + value;
     fn len(field_nr: i32, value: Self::RustType<'_>) -> usize {
         let tag = (field_nr << 3) | (Self::WIRE_TYPE as i32);
@@ -195,7 +362,7 @@ pub trait ProtobufScalar {
 }
 
 macro_rules! implscalar {
-    ($t:ident, $rt:ty, $wt:expr, $f:expr, $fl:expr) => {
+    ($t:ident, $rt:ty, $wt:expr, $f:expr, $fl:expr, $fr:expr) => {
         impl ProtobufScalar for $t {
             type RustType<'a> = $rt;
             const WIRE_TYPE: WireType = $wt;
@@ -205,34 +372,136 @@ macro_rules! implscalar {
             fn value_len(value: Self::RustType<'_>) -> usize {
                 $fl(value)
             }
+            fn read<'a>(buf: &mut &'a [u8]) -> Result<Self::RustType<'a>, DecodeError> {
+                $fr(buf)
+            }
         }
     };
 }
 
-implscalar!(Int32, i32, WireType::VARINT, write_int32, len_of_int32);
-implscalar!(Sint32, i32, WireType::VARINT, write_sint32, len_of_sint32);
-implscalar!(Int64, i64, WireType::VARINT, write_int64, len_of_int64);
-implscalar!(Sint64, i64, WireType::VARINT, write_sint64, len_of_sint64);
-implscalar!(Uint32, u32, WireType::VARINT, write_uint32, len_of_uint32);
-implscalar!(Uint64, u64, WireType::VARINT, write_uint64, len_of_uint64);
-implscalar!(Bool, bool, WireType::VARINT, write_bool, len_of_value);
-implscalar!(Fixed32, u32, WireType::I32, write_fixed32, len_of_value);
-implscalar!(Sfixed32, i32, WireType::I32, write_sfixed32, len_of_value);
-implscalar!(Float, f32, WireType::I32, write_float, len_of_value);
-implscalar!(Fixed64, u64, WireType::I64, write_fixed64, len_of_value);
-implscalar!(Sfixed64, i64, WireType::I64, write_sfixed64, len_of_value);
-implscalar!(Double, f64, WireType::I64, write_double, len_of_value);
+implscalar!(
+    Int32,
+    i32,
+    WireType::VARINT,
+    write_int32,
+    len_of_int32,
+    decode_int32
+);
+implscalar!(
+    Sint32,
+    i32,
+    WireType::VARINT,
+    write_sint32,
+    len_of_sint32,
+    decode_sint32
+);
+implscalar!(
+    Int64,
+    i64,
+    WireType::VARINT,
+    write_int64,
+    len_of_int64,
+    decode_int64
+);
+implscalar!(
+    Sint64,
+    i64,
+    WireType::VARINT,
+    write_sint64,
+    len_of_sint64,
+    decode_sint64
+);
+implscalar!(
+    Uint32,
+    u32,
+    WireType::VARINT,
+    write_uint32,
+    len_of_uint32,
+    decode_uint32
+);
+implscalar!(
+    Uint64,
+    u64,
+    WireType::VARINT,
+    write_uint64,
+    len_of_uint64,
+    decode_uint64
+);
+implscalar!(
+    Bool,
+    bool,
+    WireType::VARINT,
+    write_bool,
+    len_of_value,
+    decode_bool
+);
+implscalar!(
+    Fixed32,
+    u32,
+    WireType::I32,
+    write_fixed32,
+    len_of_value,
+    decode_fixed32
+);
+implscalar!(
+    Sfixed32,
+    i32,
+    WireType::I32,
+    write_sfixed32,
+    len_of_value,
+    decode_sfixed32
+);
+implscalar!(
+    Float,
+    f32,
+    WireType::I32,
+    write_float,
+    len_of_value,
+    decode_float
+);
+implscalar!(
+    Fixed64,
+    u64,
+    WireType::I64,
+    write_fixed64,
+    len_of_value,
+    decode_fixed64
+);
+implscalar!(
+    Sfixed64,
+    i64,
+    WireType::I64,
+    write_sfixed64,
+    len_of_value,
+    decode_sfixed64
+);
+implscalar!(
+    Double,
+    f64,
+    WireType::I64,
+    write_double,
+    len_of_value,
+    decode_double
+);
 implscalar!(
     PbString,
     &'a str,
     WireType::LEN,
     write_string,
-    len_of_string
+    len_of_string,
+    decode_string
 );
-implscalar!(PbBytes, &'a [u8], WireType::LEN, write_bytes, len_of_bytes);
+implscalar!(
+    PbBytes,
+    &'a [u8],
+    WireType::LEN,
+    write_bytes,
+    len_of_bytes,
+    decode_bytes
+);
 
 // https://protobuf.dev/programming-guides/encoding/#structure
-#[repr(usize)]
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WireType {
     VARINT = 0, //	int32, int64, uint32, uint64, sint32, sint64, bool, enum
@@ -291,34 +560,6 @@ impl From<core::str::Utf8Error> for DecodeError {
 }
 
 #[inline]
-pub const fn decode_zigzag32(n: u32) -> i32 {
-    ((n >> 1) as i32) ^ (-((n & 1) as i32))
-}
-
-#[inline]
-pub const fn decode_zigzag64(n: u64) -> i64 {
-    ((n >> 1) as i64) ^ (-((n & 1) as i64))
-}
-
-#[inline]
-pub fn decode_varint(buf: &mut &[u8]) -> Result<u64, DecodeError> {
-    let mut result: u64 = 0;
-    let mut shift = 0u32;
-    loop {
-        let &b = buf.first().ok_or(DecodeError::Truncated)?;
-        *buf = &buf[1..];
-        result |= ((b & 0x7F) as u64) << shift;
-        if b & 0x80 == 0 {
-            return Ok(result);
-        }
-        shift += 7;
-        if shift >= 64 {
-            return Err(DecodeError::Truncated);
-        }
-    }
-}
-
-#[inline]
 pub fn decode_key(buf: &mut &[u8]) -> Result<(u32, WireType), DecodeError> {
     let v = decode_varint(buf)?;
     let tag = (v >> 3) as u32;
@@ -331,18 +572,6 @@ pub fn decode_key(buf: &mut &[u8]) -> Result<(u32, WireType), DecodeError> {
         other => return Err(DecodeError::InvalidWireType(other)),
     };
     Ok((tag, wire_type))
-}
-
-/// Decode a length-delimited field, returning a sub-slice of the input.
-#[inline]
-pub fn decode_len<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], DecodeError> {
-    let len = decode_varint(buf)? as usize;
-    if buf.len() < len {
-        return Err(DecodeError::Truncated);
-    }
-    let (data, rest) = buf.split_at(len);
-    *buf = rest;
-    Ok(data)
 }
 
 #[inline]
@@ -385,183 +614,4 @@ pub fn skip_field(wire_type: WireType, buf: &mut &[u8]) -> Result<(), DecodeErro
         }
     }
     Ok(())
-}
-
-// --- Packed iterators ---
-
-/// Zero-copy iterator over packed varint-encoded values.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PackedVarints<'a>(pub &'a [u8]);
-
-impl<'a> PackedVarints<'a> {
-    pub fn int32s(self) -> impl Iterator<Item = Result<i32, DecodeError>> + 'a {
-        self.map(|r| r.map(|v| v as i32))
-    }
-    pub fn sint32s(self) -> impl Iterator<Item = Result<i32, DecodeError>> + 'a {
-        self.map(|r| r.map(|v| decode_zigzag32(v as u32)))
-    }
-    pub fn int64s(self) -> impl Iterator<Item = Result<i64, DecodeError>> + 'a {
-        self.map(|r| r.map(|v| v as i64))
-    }
-    pub fn sint64s(self) -> impl Iterator<Item = Result<i64, DecodeError>> + 'a {
-        self.map(|r| r.map(decode_zigzag64))
-    }
-    pub fn uint32s(self) -> impl Iterator<Item = Result<u32, DecodeError>> + 'a {
-        self.map(|r| r.map(|v| v as u32))
-    }
-    pub fn uint64s(self) -> impl Iterator<Item = Result<u64, DecodeError>> + 'a {
-        self.map(|r| r.map(|v| v))
-    }
-    pub fn bools(self) -> impl Iterator<Item = Result<bool, DecodeError>> + 'a {
-        self.map(|r| r.map(|v| v != 0))
-    }
-    pub fn enums<E: TryFrom<i32>>(self) -> impl Iterator<Item = Result<E, DecodeError>> + 'a {
-        self.map(|r| {
-            r.and_then(|v| {
-                E::try_from(v as i32).map_err(|_| DecodeError::InvalidEnumValue {
-                    field: "<packed>",
-                    value: v as i32,
-                })
-            })
-        })
-    }
-}
-
-impl<'a> Iterator for PackedVarints<'a> {
-    type Item = Result<u64, DecodeError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.0.is_empty() {
-            return None;
-        }
-        Some(decode_varint(&mut self.0))
-    }
-}
-
-/// Zero-copy iterator over packed fixed 32-bit values.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PackedFixed32s<'a>(pub &'a [u8]);
-
-impl<'a> PackedFixed32s<'a> {
-    pub fn u32s(self) -> impl Iterator<Item = Result<u32, DecodeError>> + 'a {
-        self.map(|r| r.map(u32::from_le_bytes))
-    }
-    pub fn i32s(self) -> impl Iterator<Item = Result<i32, DecodeError>> + 'a {
-        self.map(|r| r.map(i32::from_le_bytes))
-    }
-    pub fn f32s(self) -> impl Iterator<Item = Result<f32, DecodeError>> + 'a {
-        self.map(|r| r.map(f32::from_le_bytes))
-    }
-}
-
-impl<'a> Iterator for PackedFixed32s<'a> {
-    type Item = Result<[u8; 4], DecodeError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.0.is_empty() {
-            return None;
-        }
-        if self.0.len() < 4 {
-            self.0 = &[];
-            return Some(Err(DecodeError::Truncated));
-        }
-        let (val, rest) = self.0.split_at(4);
-        self.0 = rest;
-        Some(Ok(val.try_into().unwrap()))
-    }
-}
-
-/// Zero-copy iterator over packed fixed 64-bit values.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct PackedFixed64s<'a>(pub &'a [u8]);
-
-impl<'a> PackedFixed64s<'a> {
-    pub fn u64s(self) -> impl Iterator<Item = Result<u64, DecodeError>> + 'a {
-        self.map(|r| r.map(u64::from_le_bytes))
-    }
-    pub fn i64s(self) -> impl Iterator<Item = Result<i64, DecodeError>> + 'a {
-        self.map(|r| r.map(i64::from_le_bytes))
-    }
-    pub fn f64s(self) -> impl Iterator<Item = Result<f64, DecodeError>> + 'a {
-        self.map(|r| r.map(f64::from_le_bytes))
-    }
-}
-
-impl<'a> Iterator for PackedFixed64s<'a> {
-    type Item = Result<[u8; 8], DecodeError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.0.is_empty() {
-            return None;
-        }
-        if self.0.len() < 8 {
-            self.0 = &[];
-            return Some(Err(DecodeError::Truncated));
-        }
-        let (val, rest) = self.0.split_at(8);
-        self.0 = rest;
-        Some(Ok(val.try_into().unwrap()))
-    }
-}
-
-// Fixed-width decode functions
-
-#[inline]
-pub fn decode_i64(buf: &mut &[u8]) -> Result<i64, DecodeError> {
-    if buf.len() < 8 {
-        return Err(DecodeError::Truncated);
-    }
-    let val = i64::from_le_bytes(buf[..8].try_into().unwrap());
-    *buf = &buf[8..];
-    Ok(val)
-}
-
-#[inline]
-pub fn decode_u64(buf: &mut &[u8]) -> Result<u64, DecodeError> {
-    if buf.len() < 8 {
-        return Err(DecodeError::Truncated);
-    }
-    let val = u64::from_le_bytes(buf[..8].try_into().unwrap());
-    *buf = &buf[8..];
-    Ok(val)
-}
-
-#[inline]
-pub fn decode_f64(buf: &mut &[u8]) -> Result<f64, DecodeError> {
-    if buf.len() < 8 {
-        return Err(DecodeError::Truncated);
-    }
-    let val = f64::from_le_bytes(buf[..8].try_into().unwrap());
-    *buf = &buf[8..];
-    Ok(val)
-}
-
-#[inline]
-pub fn decode_i32(buf: &mut &[u8]) -> Result<i32, DecodeError> {
-    if buf.len() < 4 {
-        return Err(DecodeError::Truncated);
-    }
-    let val = i32::from_le_bytes(buf[..4].try_into().unwrap());
-    *buf = &buf[4..];
-    Ok(val)
-}
-
-#[inline]
-pub fn decode_u32(buf: &mut &[u8]) -> Result<u32, DecodeError> {
-    if buf.len() < 4 {
-        return Err(DecodeError::Truncated);
-    }
-    let val = u32::from_le_bytes(buf[..4].try_into().unwrap());
-    *buf = &buf[4..];
-    Ok(val)
-}
-
-#[inline]
-pub fn decode_f32(buf: &mut &[u8]) -> Result<f32, DecodeError> {
-    if buf.len() < 4 {
-        return Err(DecodeError::Truncated);
-    }
-    let val = f32::from_le_bytes(buf[..4].try_into().unwrap());
-    *buf = &buf[4..];
-    Ok(val)
 }

--- a/src/tack.rs
+++ b/src/tack.rs
@@ -110,7 +110,7 @@ mod tests {
             for i in 2..=5 {
                 write_wide_varint(i, 15723, &mut buf);
                 println!("{buf:?}");
-                let dec = prost::encoding::decode_varint(&mut buf.as_slice());
+                let dec = crate::scalars::decode_varint(&mut buf.as_slice());
                 println!("{dec:?}");
                 buf.clear()
             }

--- a/src/typed_writers.rs
+++ b/src/typed_writers.rs
@@ -170,7 +170,6 @@ pub mod packed {
     use super::*;
     //todo: not all scalars can be packed (strings, bytes),
     // make this more typesafe by not implementing it on those.
-
     impl<'b, const N: usize, P> FieldWriter<'b, N, Packed<P>> {
         #[inline]
         pub fn write<V: ProtoEncode<P>>(
@@ -186,6 +185,31 @@ pub mod packed {
             }
             drop(t);
             Field::new()
+        }
+    }
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub struct PackedIter<'a, T: ProtobufScalar> {
+        buf: &'a [u8],
+        _t: PhantomData<T>,
+    }
+
+    impl<'a, T: ProtobufScalar> PackedIter<'a, T> {
+        pub fn new(buf: &'a [u8]) -> Self {
+            Self {
+                buf,
+                _t: PhantomData,
+            }
+        }
+    }
+
+    impl<'a, T: ProtobufScalar> Iterator for PackedIter<'a, T> {
+        type Item = Result<T::RustType<'a>, DecodeError>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let mut buf = self.buf;
+            let out = Some(T::read(&mut buf));
+            self.buf = buf;
+            out
         }
     }
 }
@@ -234,6 +258,18 @@ pub struct MapEntryWriter<'b, const N: usize, K, V> {
     _pbtype: PhantomData<(K, V)>,
 }
 
+pub struct SimpleMapEntry<'a, K: ProtobufScalar, V: ProtobufScalar> {
+    pub key: K::RustType<'a>,
+    pub value: V::RustType<'a>,
+}
+impl<'a, K: ProtobufScalar, V: ProtobufScalar> SimpleMapEntry<'a, K, V> {
+    pub fn read(buf: &mut &'a [u8]) -> Result<Self, DecodeError> {
+        let mut entry_buf = decode_len(buf)?;
+        let key = K::read(&mut entry_buf)?;
+        let value = V::read(&mut entry_buf)?;
+        Ok(Self { key, value })
+    }
+}
 impl<'b, const N: usize, K: ProtobufScalar, V: ProtobufScalar> MapEntryWriter<'b, N, K, V> {
     pub fn new(buf: &'b mut Vec<u8>) -> Self {
         Self {

--- a/src/typed_writers.rs
+++ b/src/typed_writers.rs
@@ -206,10 +206,13 @@ pub mod packed {
         type Item = Result<T::RustType<'a>, DecodeError>;
 
         fn next(&mut self) -> Option<Self::Item> {
+            if self.buf.is_empty() {
+                return None;
+            }
             let mut buf = self.buf;
-            let out = Some(T::read(&mut buf));
-            self.buf = buf;
-            out
+            let out = T::read(&mut buf);
+            self.buf = if out.is_ok() { buf } else { &[] };
+            Some(out)
         }
     }
 }

--- a/tacky-build/src/field_enum.rs
+++ b/tacky-build/src/field_enum.rs
@@ -1,0 +1,223 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::parser::{Field, Label, PbType, Scalar};
+
+/// Whether a field's variant borrows from the input buffer (needs lifetime 'a).
+fn field_borrows(field: &Field) -> bool {
+    match field.label {
+        Label::Packed => true, // packed → &'a [u8]
+        _ => match &field.ty {
+            PbType::Scalar(Scalar::String) | PbType::Scalar(Scalar::Bytes) => true,
+            PbType::Message(_) | PbType::Map(_, _) | PbType::SimpleMap(_, _) => true,
+            _ => false,
+        },
+    }
+}
+
+/// The Rust type carried by this field's enum variant.
+fn variant_type(field: &Field) -> TokenStream {
+    match field.label {
+        Label::Packed => quote!(&'a [u8]),
+        _ => match &field.ty {
+            PbType::Scalar(s) => scalar_variant_type(s),
+            PbType::Enum(_) => quote!(i32),
+            PbType::Message(_) => quote!(&'a [u8]),
+            PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote!(&'a [u8]),
+        },
+    }
+}
+
+fn scalar_variant_type(s: &Scalar) -> TokenStream {
+    match s {
+        Scalar::Int32 => quote!(i32),
+        Scalar::Sint32 => quote!(i32),
+        Scalar::Int64 => quote!(i64),
+        Scalar::Sint64 => quote!(i64),
+        Scalar::Uint32 => quote!(u32),
+        Scalar::Uint64 => quote!(u64),
+        Scalar::Bool => quote!(bool),
+        Scalar::Fixed32 => quote!(u32),
+        Scalar::Sfixed32 => quote!(i32),
+        Scalar::Float => quote!(f32),
+        Scalar::Fixed64 => quote!(u64),
+        Scalar::Sfixed64 => quote!(i64),
+        Scalar::Double => quote!(f64),
+        Scalar::String => quote!(&'a str),
+        Scalar::Bytes => quote!(&'a [u8]),
+    }
+}
+
+/// The WireType constant for this field.
+fn wire_type_token(field: &Field) -> TokenStream {
+    match field.label {
+        Label::Packed => quote!(tacky::WireType::LEN),
+        _ => match &field.ty {
+            PbType::Scalar(s) => scalar_wire_type_token(s),
+            PbType::Enum(_) => quote!(tacky::WireType::VARINT),
+            PbType::Message(_) => quote!(tacky::WireType::LEN),
+            PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote!(tacky::WireType::LEN),
+        },
+    }
+}
+
+fn scalar_wire_type_token(s: &Scalar) -> TokenStream {
+    match s {
+        Scalar::Int32 | Scalar::Sint32 | Scalar::Int64 | Scalar::Sint64 | Scalar::Uint32
+        | Scalar::Uint64 | Scalar::Bool => quote!(tacky::WireType::VARINT),
+        Scalar::Fixed32 | Scalar::Sfixed32 | Scalar::Float => quote!(tacky::WireType::I32),
+        Scalar::Fixed64 | Scalar::Sfixed64 | Scalar::Double => quote!(tacky::WireType::I64),
+        Scalar::String | Scalar::Bytes => quote!(tacky::WireType::LEN),
+    }
+}
+
+/// The decode expression for a field, assuming wire type has already been checked.
+fn decode_expr(field: &Field) -> TokenStream {
+    match field.label {
+        Label::Packed => {
+            // All packed fields just return raw bytes for user to iterate
+            quote! {
+                let data = tacky::decode_len(buf)?;
+            }
+        }
+        _ => match &field.ty {
+            PbType::Scalar(s) => scalar_decode_expr(s),
+            PbType::Enum(_) => quote! {
+                let val = tacky::decode_varint(buf)? as i32;
+            },
+            PbType::Message(_) => quote! {
+                let data = tacky::decode_len(buf)?;
+            },
+            PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote! {
+                let data = tacky::decode_len(buf)?;
+            },
+        },
+    }
+}
+
+fn scalar_decode_expr(s: &Scalar) -> TokenStream {
+    match s {
+        Scalar::Int32 => quote! { let val = tacky::decode_varint(buf)? as i32; },
+        Scalar::Int64 => quote! { let val = tacky::decode_varint(buf)? as i64; },
+        Scalar::Uint32 => quote! { let val = tacky::decode_varint(buf)? as u32; },
+        Scalar::Uint64 => quote! { let val = tacky::decode_varint(buf)?; },
+        Scalar::Sint32 => quote! {
+            let val = tacky::decode_zigzag32(tacky::decode_varint(buf)? as u32);
+        },
+        Scalar::Sint64 => quote! {
+            let val = tacky::decode_zigzag64(tacky::decode_varint(buf)?);
+        },
+        Scalar::Bool => quote! { let val = tacky::decode_varint(buf)? != 0; },
+        Scalar::Fixed32 => quote! { let val = tacky::decode_u32(buf)?; },
+        Scalar::Sfixed32 => quote! { let val = tacky::decode_i32(buf)?; },
+        Scalar::Float => quote! { let val = tacky::decode_f32(buf)?; },
+        Scalar::Fixed64 => quote! { let val = tacky::decode_u64(buf)?; },
+        Scalar::Sfixed64 => quote! { let val = tacky::decode_i64(buf)?; },
+        Scalar::Double => quote! { let val = tacky::decode_f64(buf)?; },
+        Scalar::String => quote! {
+            let data = tacky::decode_len(buf)?;
+            let val = core::str::from_utf8(data)?;
+        },
+        Scalar::Bytes => quote! {
+            let data = tacky::decode_len(buf)?;
+        },
+    }
+}
+
+/// The value expression to wrap in `Some(Self::Variant(...))`.
+fn variant_value_expr(field: &Field) -> TokenStream {
+    match field.label {
+        Label::Packed => quote!(data),
+        _ => match &field.ty {
+            PbType::Scalar(Scalar::String) => quote!(val),
+            PbType::Scalar(Scalar::Bytes) => quote!(data),
+            PbType::Scalar(_) | PbType::Enum(_) => quote!(val),
+            PbType::Message(_) | PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote!(data),
+        },
+    }
+}
+
+pub fn write_field_enum(name: &str, fields: &[Field]) -> TokenStream {
+    let enum_name = format_ident!("{name}Field");
+
+    let needs_lifetime = fields.iter().any(field_borrows);
+
+    // Generate variant definitions
+    let variants: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let variant_name =
+                format_ident!("{}", heck::AsUpperCamelCase(&f.name).to_string());
+            let ty = variant_type(f);
+            quote! { #variant_name(#ty) }
+        })
+        .collect();
+
+    // Generate match arms for decode
+    let match_arms: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let tag = f.number as u32;
+            let variant_name =
+                format_ident!("{}", heck::AsUpperCamelCase(&f.name).to_string());
+            let field_name_str = &f.name;
+            let wt = wire_type_token(f);
+            let decode = decode_expr(f);
+            let value = variant_value_expr(f);
+
+            quote! {
+                #tag => {
+                    tacky::check_wire_type(wire_type, #wt, #field_name_str)?;
+                    #decode
+                    Ok(Some(Self::#variant_name(#value)))
+                }
+            }
+        })
+        .collect();
+
+    if needs_lifetime {
+        quote! {
+            #[derive(Debug, Copy, Clone, PartialEq)]
+            pub enum #enum_name<'a> {
+                #(#variants,)*
+            }
+
+            impl<'a> #enum_name<'a> {
+                /// Decode the next field from the buffer.
+                /// Returns `Ok(Some(field))` for known fields, `Ok(None)` for unknown (skipped).
+                pub fn decode(buf: &mut &'a [u8]) -> Result<Option<Self>, tacky::DecodeError> {
+                    let (tag, wire_type) = tacky::decode_key(buf)?;
+                    match tag {
+                        #(#match_arms)*
+                        _ => {
+                            tacky::skip_field(wire_type, buf)?;
+                            Ok(None)
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[derive(Debug, Copy, Clone, PartialEq)]
+            pub enum #enum_name {
+                #(#variants,)*
+            }
+
+            impl #enum_name {
+                /// Decode the next field from the buffer.
+                /// Returns `Ok(Some(field))` for known fields, `Ok(None)` for unknown (skipped).
+                pub fn decode(buf: &mut &[u8]) -> Result<Option<Self>, tacky::DecodeError> {
+                    let (tag, wire_type) = tacky::decode_key(buf)?;
+                    match tag {
+                        #(#match_arms)*
+                        _ => {
+                            tacky::skip_field(wire_type, buf)?;
+                            Ok(None)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tacky-build/src/field_enum.rs
+++ b/tacky-build/src/field_enum.rs
@@ -18,13 +18,30 @@ fn field_borrows(field: &Field) -> bool {
 /// The Rust type carried by this field's enum variant.
 fn variant_type(field: &Field) -> TokenStream {
     match field.label {
-        Label::Packed => quote!(&'a [u8]),
+        Label::Packed => packed_variant_type(field),
         _ => match &field.ty {
             PbType::Scalar(s) => scalar_variant_type(s),
             PbType::Enum(_) => quote!(i32),
             PbType::Message(_) => quote!(&'a [u8]),
             PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote!(&'a [u8]),
         },
+    }
+}
+
+fn packed_variant_type(field: &Field) -> TokenStream {
+    match &field.ty {
+        PbType::Scalar(s) => match s {
+            Scalar::Fixed32 | Scalar::Sfixed32 | Scalar::Float => {
+                quote!(tacky::PackedFixed32s<'a>)
+            }
+            Scalar::Fixed64 | Scalar::Sfixed64 | Scalar::Double => {
+                quote!(tacky::PackedFixed64s<'a>)
+            }
+            _ => quote!(tacky::PackedVarints<'a>),
+        },
+        // Enum packed fields are varint-encoded
+        PbType::Enum(_) => quote!(tacky::PackedVarints<'a>),
+        _ => quote!(tacky::PackedVarints<'a>),
     }
 }
 
@@ -125,9 +142,25 @@ fn scalar_decode_expr(s: &Scalar) -> TokenStream {
 }
 
 /// The value expression to wrap in `Some(Self::Variant(...))`.
+fn packed_value_expr(field: &Field) -> TokenStream {
+    match &field.ty {
+        PbType::Scalar(s) => match s {
+            Scalar::Fixed32 | Scalar::Sfixed32 | Scalar::Float => {
+                quote!(tacky::PackedFixed32s(data))
+            }
+            Scalar::Fixed64 | Scalar::Sfixed64 | Scalar::Double => {
+                quote!(tacky::PackedFixed64s(data))
+            }
+            _ => quote!(tacky::PackedVarints(data)),
+        },
+        PbType::Enum(_) => quote!(tacky::PackedVarints(data)),
+        _ => quote!(tacky::PackedVarints(data)),
+    }
+}
+
 fn variant_value_expr(field: &Field) -> TokenStream {
     match field.label {
-        Label::Packed => quote!(data),
+        Label::Packed => packed_value_expr(field),
         _ => match &field.ty {
             PbType::Scalar(Scalar::String) => quote!(val),
             PbType::Scalar(Scalar::Bytes) => quote!(data),

--- a/tacky-build/src/field_enum.rs
+++ b/tacky-build/src/field_enum.rs
@@ -21,7 +21,10 @@ fn variant_type(field: &Field) -> TokenStream {
         Label::Packed => packed_variant_type(field),
         _ => match &field.ty {
             PbType::Scalar(s) => scalar_variant_type(s),
-            PbType::Enum(_) => quote!(i32),
+            PbType::Enum((name, _)) => {
+                let ident = format_ident!("{}", name);
+                quote!(#ident)
+            }
             PbType::Message(_) => quote!(&'a [u8]),
             PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote!(&'a [u8]),
         },
@@ -99,9 +102,17 @@ fn decode_expr(field: &Field) -> TokenStream {
         }
         _ => match &field.ty {
             PbType::Scalar(s) => scalar_decode_expr(s),
-            PbType::Enum(_) => quote! {
-                let val = tacky::decode_varint(buf)? as i32;
-            },
+            PbType::Enum((name, _)) => {
+                let ident = format_ident!("{}", name);
+                let field_name_str = &field.name;
+                quote! {
+                    let raw = tacky::decode_varint(buf)? as i32;
+                    let val = #ident::try_from(raw).map_err(|_| tacky::DecodeError::InvalidEnumValue {
+                        field: #field_name_str,
+                        value: raw,
+                    })?;
+                }
+            }
             PbType::Message(_) => quote! {
                 let data = tacky::decode_len(buf)?;
             },

--- a/tacky-build/src/field_enum.rs
+++ b/tacky-build/src/field_enum.rs
@@ -33,18 +33,13 @@ fn variant_type(field: &Field) -> TokenStream {
 
 fn packed_variant_type(field: &Field) -> TokenStream {
     match &field.ty {
-        PbType::Scalar(s) => match s {
-            Scalar::Fixed32 | Scalar::Sfixed32 | Scalar::Float => {
-                quote!(tacky::PackedFixed32s<'a>)
-            }
-            Scalar::Fixed64 | Scalar::Sfixed64 | Scalar::Double => {
-                quote!(tacky::PackedFixed64s<'a>)
-            }
-            _ => quote!(tacky::PackedVarints<'a>),
-        },
-        // Enum packed fields are varint-encoded
-        PbType::Enum(_) => quote!(tacky::PackedVarints<'a>),
-        _ => quote!(tacky::PackedVarints<'a>),
+        PbType::Scalar(s) => {
+            let t = s.tacky_type();
+            let ty_ident = format_ident!("{t}");
+            quote!(tacky::packed::PackedIter::<'a, #ty_ident>)
+        }
+        PbType::Enum(_) => quote!(tacky::packed::PackedIter::<'a, Int32>),
+        _ => quote!(tacky::packed::PackedIter::<'a, Int32>),
     }
 }
 
@@ -83,8 +78,13 @@ fn wire_type_token(field: &Field) -> TokenStream {
 
 fn scalar_wire_type_token(s: &Scalar) -> TokenStream {
     match s {
-        Scalar::Int32 | Scalar::Sint32 | Scalar::Int64 | Scalar::Sint64 | Scalar::Uint32
-        | Scalar::Uint64 | Scalar::Bool => quote!(tacky::WireType::VARINT),
+        Scalar::Int32
+        | Scalar::Sint32
+        | Scalar::Int64
+        | Scalar::Sint64
+        | Scalar::Uint32
+        | Scalar::Uint64
+        | Scalar::Bool => quote!(tacky::WireType::VARINT),
         Scalar::Fixed32 | Scalar::Sfixed32 | Scalar::Float => quote!(tacky::WireType::I32),
         Scalar::Fixed64 | Scalar::Sfixed64 | Scalar::Double => quote!(tacky::WireType::I64),
         Scalar::String | Scalar::Bytes => quote!(tacky::WireType::LEN),
@@ -106,7 +106,7 @@ fn decode_expr(field: &Field) -> TokenStream {
                 let ident = format_ident!("{}", name);
                 let field_name_str = &field.name;
                 quote! {
-                    let raw = tacky::decode_varint(buf)? as i32;
+                    let raw = <Int32 as tacky::ProtobufScalar>::read(buf)?; // enums are always varint-encoded
                     let val = #ident::try_from(raw).map_err(|_| tacky::DecodeError::InvalidEnumValue {
                         field: #field_name_str,
                         value: raw,
@@ -124,48 +124,23 @@ fn decode_expr(field: &Field) -> TokenStream {
 }
 
 fn scalar_decode_expr(s: &Scalar) -> TokenStream {
-    match s {
-        Scalar::Int32 => quote! { let val = tacky::decode_varint(buf)? as i32; },
-        Scalar::Int64 => quote! { let val = tacky::decode_varint(buf)? as i64; },
-        Scalar::Uint32 => quote! { let val = tacky::decode_varint(buf)? as u32; },
-        Scalar::Uint64 => quote! { let val = tacky::decode_varint(buf)?; },
-        Scalar::Sint32 => quote! {
-            let val = tacky::decode_zigzag32(tacky::decode_varint(buf)? as u32);
-        },
-        Scalar::Sint64 => quote! {
-            let val = tacky::decode_zigzag64(tacky::decode_varint(buf)?);
-        },
-        Scalar::Bool => quote! { let val = tacky::decode_varint(buf)? != 0; },
-        Scalar::Fixed32 => quote! { let val = tacky::decode_u32(buf)?; },
-        Scalar::Sfixed32 => quote! { let val = tacky::decode_i32(buf)?; },
-        Scalar::Float => quote! { let val = tacky::decode_f32(buf)?; },
-        Scalar::Fixed64 => quote! { let val = tacky::decode_u64(buf)?; },
-        Scalar::Sfixed64 => quote! { let val = tacky::decode_i64(buf)?; },
-        Scalar::Double => quote! { let val = tacky::decode_f64(buf)?; },
-        Scalar::String => quote! {
-            let data = tacky::decode_len(buf)?;
-            let val = core::str::from_utf8(data)?;
-        },
-        Scalar::Bytes => quote! {
-            let data = tacky::decode_len(buf)?;
-        },
+    let t = s.tacky_type();
+    let ty_ident = format_ident!("{t}");
+    quote! {
+        let val = <#ty_ident as tacky::ProtobufScalar>::read(buf)?;
     }
 }
 
 /// The value expression to wrap in `Some(Self::Variant(...))`.
 fn packed_value_expr(field: &Field) -> TokenStream {
     match &field.ty {
-        PbType::Scalar(s) => match s {
-            Scalar::Fixed32 | Scalar::Sfixed32 | Scalar::Float => {
-                quote!(tacky::PackedFixed32s(data))
-            }
-            Scalar::Fixed64 | Scalar::Sfixed64 | Scalar::Double => {
-                quote!(tacky::PackedFixed64s(data))
-            }
-            _ => quote!(tacky::PackedVarints(data)),
-        },
-        PbType::Enum(_) => quote!(tacky::PackedVarints(data)),
-        _ => quote!(tacky::PackedVarints(data)),
+        PbType::Scalar(s) => {
+            let t = s.tacky_type();
+            let ty_ident = format_ident!("{t}");
+            quote!(tacky::packed::PackedIter::<#ty_ident>::new(data))
+        }
+        PbType::Enum(_) => quote!(tacky::packed::PackedIter::<'a, Int32>::new(data)),
+        _ => quote!(tacky::packed::PackedIter::<'a, Int32>::new(data)),
     }
 }
 
@@ -174,7 +149,7 @@ fn variant_value_expr(field: &Field) -> TokenStream {
         Label::Packed => packed_value_expr(field),
         _ => match &field.ty {
             PbType::Scalar(Scalar::String) => quote!(val),
-            PbType::Scalar(Scalar::Bytes) => quote!(data),
+            PbType::Scalar(Scalar::Bytes) => quote!(val),
             PbType::Scalar(_) | PbType::Enum(_) => quote!(val),
             PbType::Message(_) | PbType::Map(_, _) | PbType::SimpleMap(_, _) => quote!(data),
         },
@@ -190,8 +165,7 @@ pub fn write_field_enum(name: &str, fields: &[Field]) -> TokenStream {
     let variants: Vec<TokenStream> = fields
         .iter()
         .map(|f| {
-            let variant_name =
-                format_ident!("{}", heck::AsUpperCamelCase(&f.name).to_string());
+            let variant_name = format_ident!("{}", heck::AsUpperCamelCase(&f.name).to_string());
             let ty = variant_type(f);
             quote! { #variant_name(#ty) }
         })
@@ -202,8 +176,7 @@ pub fn write_field_enum(name: &str, fields: &[Field]) -> TokenStream {
         .iter()
         .map(|f| {
             let tag = f.number as u32;
-            let variant_name =
-                format_ident!("{}", heck::AsUpperCamelCase(&f.name).to_string());
+            let variant_name = format_ident!("{}", heck::AsUpperCamelCase(&f.name).to_string());
             let field_name_str = &f.name;
             let wt = wire_type_token(f);
             let decode = decode_expr(f);

--- a/tacky-build/src/lib.rs
+++ b/tacky-build/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused, dead_code)]
+mod field_enum;
 mod parser;
 mod simple_typed;
 mod witness;

--- a/tacky-build/src/parser.rs
+++ b/tacky-build/src/parser.rs
@@ -7,6 +7,7 @@ use quote::{format_ident, quote};
 use std::io::Write;
 
 use crate::{
+    field_enum::write_field_enum,
     simple_typed::get_writer,
     witness::{field_witness_type, message_def_writer},
 };
@@ -242,6 +243,7 @@ fn write_simple_message(m: &Message, desc: &FileDescriptor) -> TokenStream {
     let trait_impl = write_trait_impl(name);
     let writer_def = message_def_writer(name);
     let writer_api = write_writer_api(&fields);
+    let field_enum = write_field_enum(name, &fields);
 
     quote! {
         #struct_schema
@@ -250,6 +252,7 @@ fn write_simple_message(m: &Message, desc: &FileDescriptor) -> TokenStream {
         impl<'buf> #writer_name_ident<'buf> {
             #writer_api
         }
+        #field_enum
     }
 }
 

--- a/testing/protos/simple_message.proto
+++ b/testing/protos/simple_message.proto
@@ -14,6 +14,12 @@ message SimpleMessage {
     repeated bytes manybytes = 8;
     optional bytes abytes = 9;
     optional bool yesno = 10;
+    repeated double packed_doubles = 12 [packed=true];
+    repeated float packed_floats = 13 [packed=true];
+    repeated fixed32 packed_fixed32 = 14 [packed=true];
+    repeated fixed64 packed_fixed64 = 15 [packed=true];
+    repeated sfixed32 packed_sfixed32 = 16 [packed=true];
+    repeated sfixed64 packed_sfixed64 = 17 [packed=true];
 }
 
 

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -18,7 +18,8 @@ mod tests {
         SimpleMessage as PSimpleMessage,
     };
     use crate::tacky_proto::example::{
-        AnotherEnum, MsgWithEnums, MsgWithMaps, MsgWithNesting, SimpleEnum, SimpleMessage,
+        AnotherEnum, MsgWithEnums, MsgWithEnumsField, MsgWithMaps, MsgWithNesting,
+        MsgWithNestingField, SimpleEnum, SimpleMessage, SimpleMessageField,
     };
 
     #[test]
@@ -223,5 +224,257 @@ mod tests {
         let unpacked = PMsgWithNesting::decode(&*tacky_packed).unwrap();
         //prost can decode what tacky encodes
         assert_eq!(unpacked, prost_msg);
+    }
+
+    // --- Decode tests using generated field enums ---
+
+    #[test]
+    fn test_decode_simple_message() {
+        // Encode
+        let mut buf = Vec::new();
+        let mut writer = SimpleMessage::new_writer(&mut buf, None);
+        tacky_macros::write_proto!(
+            writer,
+            SimpleMessage {
+                normal_int: Some(42i64),
+                zigzag_int: Some(-7i64),
+                fixed_int: Some(999i64),
+                manynumbers: [10i32, 20, 30],
+                manynumbers_unpacked: [100i32, 200],
+                packed_enum: [SimpleEnum::First, SimpleEnum::Second],
+                astring: Some("hello"),
+                manystrings: ["foo", "bar"],
+                abytes: Some(&b"raw"[..]),
+                manybytes: [&b"a"[..], &b"b"[..]],
+                yesno: Some(true),
+            }
+        );
+        drop(writer);
+
+        // Decode with field enum
+        let mut remaining: &[u8] = &buf;
+        let mut normal_int = None;
+        let mut zigzag_int = None;
+        let mut fixed_int = None;
+        let mut packed_numbers: Vec<i32> = Vec::new();
+        let mut unpacked_numbers: Vec<i32> = Vec::new();
+        let mut packed_enums: Vec<i32> = Vec::new();
+        let mut astring = None;
+        let mut manystrings: Vec<&str> = Vec::new();
+        let mut abytes: Option<&[u8]> = None;
+        let mut manybytes: Vec<&[u8]> = Vec::new();
+        let mut yesno = None;
+
+        while !remaining.is_empty() {
+            let Some(field) = SimpleMessageField::decode(&mut remaining).unwrap() else {
+                continue;
+            };
+            match field {
+                SimpleMessageField::NormalInt(v) => normal_int = Some(v),
+                SimpleMessageField::ZigzagInt(v) => zigzag_int = Some(v),
+                SimpleMessageField::FixedInt(v) => fixed_int = Some(v),
+                SimpleMessageField::Manynumbers(packed) => {
+                    let mut p = packed;
+                    while !p.is_empty() {
+                        packed_numbers.push(tacky::decode_varint(&mut p).unwrap() as i32);
+                    }
+                }
+                SimpleMessageField::ManynumbersUnpacked(v) => unpacked_numbers.push(v),
+                SimpleMessageField::PackedEnum(packed) => {
+                    let mut p = packed;
+                    while !p.is_empty() {
+                        packed_enums.push(tacky::decode_varint(&mut p).unwrap() as i32);
+                    }
+                }
+                SimpleMessageField::Astring(s) => astring = Some(s),
+                SimpleMessageField::Manystrings(s) => manystrings.push(s),
+                SimpleMessageField::Abytes(b) => abytes = Some(b),
+                SimpleMessageField::Manybytes(b) => manybytes.push(b),
+                SimpleMessageField::Yesno(v) => yesno = Some(v),
+            }
+        }
+
+        assert_eq!(normal_int, Some(42));
+        assert_eq!(zigzag_int, Some(-7));
+        assert_eq!(fixed_int, Some(999));
+        assert_eq!(packed_numbers, vec![10, 20, 30]);
+        assert_eq!(unpacked_numbers, vec![100, 200]);
+        assert_eq!(packed_enums, vec![0, 1]); // First=0, Second=1
+        assert_eq!(astring, Some("hello"));
+        assert_eq!(manystrings, vec!["foo", "bar"]);
+        assert_eq!(abytes, Some(b"raw".as_slice()));
+        assert_eq!(manybytes, vec![b"a".as_slice(), b"b".as_slice()]);
+        assert_eq!(yesno, Some(true));
+    }
+
+    #[test]
+    fn test_decode_enums() {
+        let mut buf = Vec::new();
+        let mut writer = MsgWithEnums::new_writer(&mut buf, None);
+        tacky_macros::write_proto!(
+            writer,
+            MsgWithEnums {
+                enum1: Some(SimpleEnum::Second),
+                enum2: [AnotherEnum::A, AnotherEnum::B],
+            }
+        );
+        drop(writer);
+
+        let mut remaining: &[u8] = &buf;
+        let mut enum1 = None;
+        let mut enum2: Vec<i32> = Vec::new();
+
+        while !remaining.is_empty() {
+            let Some(field) = MsgWithEnumsField::decode(&mut remaining).unwrap() else {
+                continue;
+            };
+            match field {
+                MsgWithEnumsField::Enum1(v) => enum1 = Some(v),
+                MsgWithEnumsField::Enum2(v) => enum2.push(v),
+            }
+        }
+
+        assert_eq!(enum1, Some(1)); // Second = 1
+        assert_eq!(enum2, vec![0, 1]); // A=0, B=1
+    }
+
+    #[test]
+    fn test_decode_nested() {
+        let mut buf = Vec::new();
+        let mut writer = MsgWithNesting::new_writer(&mut buf, None);
+        tacky_macros::write_proto!(
+            writer,
+            MsgWithNesting {
+                enums: {
+                    writer.enums().write_msg(|mut m| {
+                        tacky_macros::write_proto!(
+                            m,
+                            MsgWithEnums {
+                                enum1: Some(SimpleEnum::First),
+                                enum2: [AnotherEnum::B],
+                            }
+                        );
+                    })
+                },
+                nested: {
+                    let mut m = writer.nested();
+                    m.append_msg_with(|mut n| {
+                        tacky_macros::write_proto!(
+                            n,
+                            SimpleMessage {
+                                normal_int: Some(77i64),
+                                zigzag_int: None::<i64>,
+                                fixed_int: None::<i64>,
+                                manynumbers: Vec::<i32>::new(),
+                                manynumbers_unpacked: Vec::<i32>::new(),
+                                packed_enum: Vec::<SimpleEnum>::new(),
+                                astring: Some("nested"),
+                                manystrings: Vec::<&str>::new(),
+                                abytes: None::<&[u8]>,
+                                manybytes: Vec::<&[u8]>::new(),
+                                yesno: None::<bool>,
+                            }
+                        );
+                    });
+                    m.close()
+                }
+            }
+        );
+        drop(writer);
+
+        let mut remaining: &[u8] = &buf;
+        let mut enums_bytes: Option<&[u8]> = None;
+        let mut nested_msgs: Vec<&[u8]> = Vec::new();
+
+        while !remaining.is_empty() {
+            let Some(field) = MsgWithNestingField::decode(&mut remaining).unwrap() else {
+                continue;
+            };
+            match field {
+                MsgWithNestingField::Enums(b) => enums_bytes = Some(b),
+                MsgWithNestingField::Nested(b) => nested_msgs.push(b),
+            }
+        }
+
+        // Decode nested MsgWithEnums
+        let mut sub = enums_bytes.unwrap();
+        let mut inner_enum1 = None;
+        let mut inner_enum2 = Vec::new();
+        while !sub.is_empty() {
+            let Some(field) = MsgWithEnumsField::decode(&mut sub).unwrap() else {
+                continue;
+            };
+            match field {
+                MsgWithEnumsField::Enum1(v) => inner_enum1 = Some(v),
+                MsgWithEnumsField::Enum2(v) => inner_enum2.push(v),
+            }
+        }
+        assert_eq!(inner_enum1, Some(0)); // First = 0
+        assert_eq!(inner_enum2, vec![1]); // B = 1
+
+        // Decode nested SimpleMessage
+        assert_eq!(nested_msgs.len(), 1);
+        let mut sub = nested_msgs[0];
+        let mut normal_int = None;
+        let mut astring = None;
+        while !sub.is_empty() {
+            let Some(field) = SimpleMessageField::decode(&mut sub).unwrap() else {
+                continue;
+            };
+            match field {
+                SimpleMessageField::NormalInt(v) => normal_int = Some(v),
+                SimpleMessageField::Astring(s) => astring = Some(s),
+                _ => {}
+            }
+        }
+        assert_eq!(normal_int, Some(77));
+        assert_eq!(astring, Some("nested"));
+    }
+
+    #[test]
+    fn test_decode_unknown_field_skipping() {
+        // Manually construct bytes with an unknown field (tag=99, varint value=42)
+        // followed by a known field (tag=10, varint yesno=1)
+        let mut buf = Vec::new();
+        // Unknown: tag=99, wire type VARINT => key = (99 << 3) | 0 = 792
+        tacky::write_varint(792, &mut buf);
+        tacky::write_varint(42, &mut buf); // some value
+        // Known: tag=10, wire type VARINT => key = (10 << 3) | 0 = 80
+        tacky::write_varint(80, &mut buf);
+        tacky::write_varint(1, &mut buf); // true
+
+        let mut remaining: &[u8] = &buf;
+        let mut yesno = None;
+        let mut skipped = 0;
+
+        while !remaining.is_empty() {
+            match SimpleMessageField::decode(&mut remaining).unwrap() {
+                Some(SimpleMessageField::Yesno(v)) => yesno = Some(v),
+                Some(_) => panic!("unexpected known field"),
+                None => skipped += 1,
+            }
+        }
+
+        assert_eq!(skipped, 1);
+        assert_eq!(yesno, Some(true));
+    }
+
+    #[test]
+    fn test_decode_wire_type_mismatch() {
+        // Construct bytes with tag=1 (normal_int, expects VARINT) but wire type LEN
+        let mut buf = Vec::new();
+        // tag=1, wire type LEN(2) => key = (1 << 3) | 2 = 10
+        tacky::write_varint(10, &mut buf);
+        tacky::write_varint(3, &mut buf); // length 3
+        buf.extend_from_slice(b"abc"); // some bytes
+
+        let mut remaining: &[u8] = &buf;
+        let result = SimpleMessageField::decode(&mut remaining);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(
+            err.contains("wire type mismatch"),
+            "expected wire type mismatch error, got: {err}"
+        );
     }
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -295,7 +295,7 @@ mod tests {
         let mut fixed_int = None;
         let mut packed_numbers: Vec<i32> = Vec::new();
         let mut unpacked_numbers: Vec<i32> = Vec::new();
-        let mut packed_enums: Vec<i32> = Vec::new();
+        let mut packed_enums: Vec<SimpleEnum> = Vec::new();
         let mut astring = None;
         let mut manystrings: Vec<&str> = Vec::new();
         let mut abytes: Option<&[u8]> = None;
@@ -321,7 +321,7 @@ mod tests {
                 }
                 SimpleMessageField::ManynumbersUnpacked(v) => unpacked_numbers.push(v),
                 SimpleMessageField::PackedEnum(iter) => {
-                    packed_enums.extend(iter.int32s().map(|r| r.unwrap()));
+                    packed_enums.extend(iter.enums::<SimpleEnum>().map(|r| r.unwrap()));
                 }
                 SimpleMessageField::Astring(s) => astring = Some(s),
                 SimpleMessageField::Manystrings(s) => manystrings.push(s),
@@ -354,7 +354,7 @@ mod tests {
         assert_eq!(fixed_int, Some(999));
         assert_eq!(packed_numbers, vec![10, 20, 30]);
         assert_eq!(unpacked_numbers, vec![100, 200]);
-        assert_eq!(packed_enums, vec![0, 1]); // First=0, Second=1
+        assert_eq!(packed_enums, vec![SimpleEnum::First, SimpleEnum::Second]);
         assert_eq!(astring, Some("hello"));
         assert_eq!(manystrings, vec!["foo", "bar"]);
         assert_eq!(abytes, Some(b"raw".as_slice()));
@@ -383,7 +383,7 @@ mod tests {
 
         let mut remaining: &[u8] = &buf;
         let mut enum1 = None;
-        let mut enum2: Vec<i32> = Vec::new();
+        let mut enum2: Vec<AnotherEnum> = Vec::new();
 
         while !remaining.is_empty() {
             let Some(field) = MsgWithEnumsField::decode(&mut remaining).unwrap() else {
@@ -395,8 +395,8 @@ mod tests {
             }
         }
 
-        assert_eq!(enum1, Some(1)); // Second = 1
-        assert_eq!(enum2, vec![0, 1]); // A=0, B=1
+        assert_eq!(enum1, Some(SimpleEnum::Second));
+        assert_eq!(enum2, vec![AnotherEnum::A, AnotherEnum::B]);
     }
 
     #[test]
@@ -476,8 +476,8 @@ mod tests {
                 MsgWithEnumsField::Enum2(v) => inner_enum2.push(v),
             }
         }
-        assert_eq!(inner_enum1, Some(0)); // First = 0
-        assert_eq!(inner_enum2, vec![1]); // B = 1
+        assert_eq!(inner_enum1, Some(SimpleEnum::First));
+        assert_eq!(inner_enum2, vec![AnotherEnum::B]);
 
         // Decode nested SimpleMessage
         assert_eq!(nested_msgs.len(), 1);

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 mod prost_proto {
     include!(concat!(env!("OUT_DIR"), "/example.rs"));
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -317,11 +317,11 @@ mod tests {
                 SimpleMessageField::ZigzagInt(v) => zigzag_int = Some(v),
                 SimpleMessageField::FixedInt(v) => fixed_int = Some(v),
                 SimpleMessageField::Manynumbers(iter) => {
-                    packed_numbers.extend(iter.int32s().map(|r| r.unwrap()));
+                    packed_numbers.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::ManynumbersUnpacked(v) => unpacked_numbers.push(v),
                 SimpleMessageField::PackedEnum(iter) => {
-                    packed_enums.extend(iter.enums::<SimpleEnum>().map(|r| r.unwrap()));
+                    packed_enums.extend(iter.map(|r| SimpleEnum::try_from(r.unwrap()).unwrap()));
                 }
                 SimpleMessageField::Astring(s) => astring = Some(s),
                 SimpleMessageField::Manystrings(s) => manystrings.push(s),
@@ -329,22 +329,22 @@ mod tests {
                 SimpleMessageField::Manybytes(b) => manybytes.push(b),
                 SimpleMessageField::Yesno(v) => yesno = Some(v),
                 SimpleMessageField::PackedDoubles(iter) => {
-                    doubles.extend(iter.f64s().map(|r| r.unwrap()));
+                    doubles.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedFloats(iter) => {
-                    floats.extend(iter.f32s().map(|r| r.unwrap()));
+                    floats.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedFixed32(iter) => {
-                    fixed32s.extend(iter.u32s().map(|r| r.unwrap()));
+                    fixed32s.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedFixed64(iter) => {
-                    fixed64s.extend(iter.u64s().map(|r| r.unwrap()));
+                    fixed64s.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedSfixed32(iter) => {
-                    sfixed32s.extend(iter.i32s().map(|r| r.unwrap()));
+                    sfixed32s.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedSfixed64(iter) => {
-                    sfixed64s.extend(iter.i64s().map(|r| r.unwrap()));
+                    sfixed64s.extend(iter.map(|r| r.unwrap()));
                 }
             }
         }
@@ -506,7 +506,7 @@ mod tests {
         // Unknown: tag=99, wire type VARINT => key = (99 << 3) | 0 = 792
         tacky::write_varint(792, &mut buf);
         tacky::write_varint(42, &mut buf); // some value
-        // Known: tag=10, wire type VARINT => key = (10 << 3) | 0 = 80
+                                           // Known: tag=10, wire type VARINT => key = (10 << 3) | 0 = 80
         tacky::write_varint(80, &mut buf);
         tacky::write_varint(1, &mut buf); // true
 
@@ -605,22 +605,22 @@ mod tests {
             };
             match field {
                 SimpleMessageField::PackedDoubles(iter) => {
-                    decoded_doubles.extend(iter.f64s().map(|r| r.unwrap()));
+                    decoded_doubles.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedFloats(iter) => {
-                    decoded_floats.extend(iter.f32s().map(|r| r.unwrap()));
+                    decoded_floats.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedFixed32(iter) => {
-                    decoded_fixed32.extend(iter.u32s().map(|r| r.unwrap()));
+                    decoded_fixed32.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedFixed64(iter) => {
-                    decoded_fixed64.extend(iter.u64s().map(|r| r.unwrap()));
+                    decoded_fixed64.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedSfixed32(iter) => {
-                    decoded_sfixed32.extend(iter.i32s().map(|r| r.unwrap()));
+                    decoded_sfixed32.extend(iter.map(|r| r.unwrap()));
                 }
                 SimpleMessageField::PackedSfixed64(iter) => {
-                    decoded_sfixed64.extend(iter.i64s().map(|r| r.unwrap()));
+                    decoded_sfixed64.extend(iter.map(|r| r.unwrap()));
                 }
                 _ => {}
             }
@@ -636,43 +636,47 @@ mod tests {
 
     #[test]
     fn test_packed_iter_edge_cases() {
+        use tacky::scalars::*;
         // Empty packed field - iterator yields nothing
-        let empty = tacky::PackedVarints(&[]);
+        fn iter<T: ProtobufScalar>(data: &[u8]) -> tacky::packed::PackedIter<'_, T> {
+            tacky::packed::PackedIter::<T>::new(data)
+        }
+        let empty = iter::<Uint64>(&[]);
         assert_eq!(empty.count(), 0);
 
-        let empty_f32 = tacky::PackedFixed32s(&[]);
+        let empty_f32 = iter::<Float>(&[]);
         assert_eq!(empty_f32.count(), 0);
 
-        let empty_f64 = tacky::PackedFixed64s(&[]);
+        let empty_f64 = iter::<Double>(&[]);
         assert_eq!(empty_f64.count(), 0);
 
         // Single element packed varint
         let mut single_buf = Vec::new();
         tacky::write_varint(42, &mut single_buf);
-        let single = tacky::PackedVarints(&single_buf);
+        let single = iter::<Uint64>(&single_buf);
         let vals: Vec<u64> = single.map(|r| r.unwrap()).collect();
         assert_eq!(vals, vec![42]);
 
         // Single element packed fixed32
         let bytes_f32 = 3.14f32.to_le_bytes();
-        let single_f32 = tacky::PackedFixed32s(&bytes_f32);
-        let vals: Vec<f32> = single_f32.f32s().map(|r| r.unwrap()).collect();
+        let single_f32 = iter::<Float>(&bytes_f32);
+        let vals: Vec<f32> = single_f32.map(|r| r.unwrap()).collect();
         assert_eq!(vals, vec![3.14f32]);
 
         // Single element packed fixed64
         let bytes_f64 = 2.718f64.to_le_bytes();
-        let single_f64 = tacky::PackedFixed64s(&bytes_f64);
-        let vals: Vec<f64> = single_f64.f64s().map(|r| r.unwrap()).collect();
+        let single_f64 = iter::<Double>(&bytes_f64);
+        let vals: Vec<f64> = single_f64.map(|r| r.unwrap()).collect();
         assert_eq!(vals, vec![2.718f64]);
 
         // Truncated fixed32 should error
-        let truncated = tacky::PackedFixed32s(&[1, 2, 3]);
+        let truncated = iter::<Float>(&[1, 2, 3]);
         let results: Vec<_> = truncated.collect();
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());
 
         // Truncated fixed64 should error
-        let truncated = tacky::PackedFixed64s(&[1, 2, 3, 4, 5, 6, 7]);
+        let truncated = iter::<Double>(&[1, 2, 3, 4, 5, 6, 7]);
         let results: Vec<_> = truncated.collect();
         assert_eq!(results.len(), 1);
         assert!(results[0].is_err());

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -32,6 +32,12 @@ mod tests {
         let manystrings = vec!["many", "strings"];
         let abytes = Vec::new();
         let manybytes: Vec<[u8; 12]> = Vec::new();
+        let packed_doubles = [1.5, 2.5, 3.5];
+        let packed_floats = [0.5f32, 1.0];
+        let packed_fixed32 = [100u32, 200];
+        let packed_fixed64 = [1000u64, 2000];
+        let packed_sfixed32 = [-1i32, -2];
+        let packed_sfixed64 = [-100i64, -200];
 
         let tacky_packed = {
             let mut buf = Vec::new();
@@ -50,6 +56,12 @@ mod tests {
                     abytes: Some(&abytes),
                     manybytes: &manybytes,
                     yesno: Some(false),
+                    packed_doubles: &packed_doubles,
+                    packed_floats: &packed_floats,
+                    packed_fixed32: &packed_fixed32,
+                    packed_fixed64: &packed_fixed64,
+                    packed_sfixed32: &packed_sfixed32,
+                    packed_sfixed64: &packed_sfixed64,
                 }
             );
             drop(writer);
@@ -73,6 +85,12 @@ mod tests {
                     prost_proto::SimpleEnum::First.into(),
                     prost_proto::SimpleEnum::Second.into(),
                 ],
+                packed_doubles: packed_doubles.to_vec(),
+                packed_floats: packed_floats.to_vec(),
+                packed_fixed32: packed_fixed32.to_vec(),
+                packed_fixed64: packed_fixed64.to_vec(),
+                packed_sfixed32: packed_sfixed32.to_vec(),
+                packed_sfixed64: packed_sfixed64.to_vec(),
             }
         };
 
@@ -179,6 +197,12 @@ mod tests {
                                         packed_enum: [SimpleEnum::First, SimpleEnum::Second],
                                         manybytes: <Vec<Vec<u8>>>::new(),
                                         yesno: Some(false),
+                                        packed_doubles: <Vec<f64>>::new(),
+                                        packed_floats: <Vec<f32>>::new(),
+                                        packed_fixed32: <Vec<u32>>::new(),
+                                        packed_fixed64: <Vec<u64>>::new(),
+                                        packed_sfixed32: <Vec<i32>>::new(),
+                                        packed_sfixed64: <Vec<i64>>::new(),
                                     }
                                 );
                             });
@@ -215,6 +239,12 @@ mod tests {
                             ],
                             manybytes: vec![],
                             yesno: Some(false),
+                            packed_doubles: vec![],
+                            packed_floats: vec![],
+                            packed_fixed32: vec![],
+                            packed_fixed64: vec![],
+                            packed_sfixed32: vec![],
+                            packed_sfixed64: vec![],
                         })
                     }
                     v
@@ -248,6 +278,12 @@ mod tests {
                 abytes: Some(&b"raw"[..]),
                 manybytes: [&b"a"[..], &b"b"[..]],
                 yesno: Some(true),
+                packed_doubles: [1.5, 2.5],
+                packed_floats: [0.5f32],
+                packed_fixed32: [42u32],
+                packed_fixed64: [999u64],
+                packed_sfixed32: [-1i32],
+                packed_sfixed64: [-100i64],
             }
         );
         drop(writer);
@@ -265,6 +301,12 @@ mod tests {
         let mut abytes: Option<&[u8]> = None;
         let mut manybytes: Vec<&[u8]> = Vec::new();
         let mut yesno = None;
+        let mut doubles: Vec<f64> = Vec::new();
+        let mut floats: Vec<f32> = Vec::new();
+        let mut fixed32s: Vec<u32> = Vec::new();
+        let mut fixed64s: Vec<u64> = Vec::new();
+        let mut sfixed32s: Vec<i32> = Vec::new();
+        let mut sfixed64s: Vec<i64> = Vec::new();
 
         while !remaining.is_empty() {
             let Some(field) = SimpleMessageField::decode(&mut remaining).unwrap() else {
@@ -274,24 +316,36 @@ mod tests {
                 SimpleMessageField::NormalInt(v) => normal_int = Some(v),
                 SimpleMessageField::ZigzagInt(v) => zigzag_int = Some(v),
                 SimpleMessageField::FixedInt(v) => fixed_int = Some(v),
-                SimpleMessageField::Manynumbers(packed) => {
-                    let mut p = packed;
-                    while !p.is_empty() {
-                        packed_numbers.push(tacky::decode_varint(&mut p).unwrap() as i32);
-                    }
+                SimpleMessageField::Manynumbers(iter) => {
+                    packed_numbers.extend(iter.int32s().map(|r| r.unwrap()));
                 }
                 SimpleMessageField::ManynumbersUnpacked(v) => unpacked_numbers.push(v),
-                SimpleMessageField::PackedEnum(packed) => {
-                    let mut p = packed;
-                    while !p.is_empty() {
-                        packed_enums.push(tacky::decode_varint(&mut p).unwrap() as i32);
-                    }
+                SimpleMessageField::PackedEnum(iter) => {
+                    packed_enums.extend(iter.int32s().map(|r| r.unwrap()));
                 }
                 SimpleMessageField::Astring(s) => astring = Some(s),
                 SimpleMessageField::Manystrings(s) => manystrings.push(s),
                 SimpleMessageField::Abytes(b) => abytes = Some(b),
                 SimpleMessageField::Manybytes(b) => manybytes.push(b),
                 SimpleMessageField::Yesno(v) => yesno = Some(v),
+                SimpleMessageField::PackedDoubles(iter) => {
+                    doubles.extend(iter.f64s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedFloats(iter) => {
+                    floats.extend(iter.f32s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedFixed32(iter) => {
+                    fixed32s.extend(iter.u32s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedFixed64(iter) => {
+                    fixed64s.extend(iter.u64s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedSfixed32(iter) => {
+                    sfixed32s.extend(iter.i32s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedSfixed64(iter) => {
+                    sfixed64s.extend(iter.i64s().map(|r| r.unwrap()));
+                }
             }
         }
 
@@ -306,6 +360,12 @@ mod tests {
         assert_eq!(abytes, Some(b"raw".as_slice()));
         assert_eq!(manybytes, vec![b"a".as_slice(), b"b".as_slice()]);
         assert_eq!(yesno, Some(true));
+        assert_eq!(doubles, vec![1.5, 2.5]);
+        assert_eq!(floats, vec![0.5]);
+        assert_eq!(fixed32s, vec![42]);
+        assert_eq!(fixed64s, vec![999]);
+        assert_eq!(sfixed32s, vec![-1]);
+        assert_eq!(sfixed64s, vec![-100]);
     }
 
     #[test]
@@ -374,6 +434,12 @@ mod tests {
                                 abytes: None::<&[u8]>,
                                 manybytes: Vec::<&[u8]>::new(),
                                 yesno: None::<bool>,
+                                packed_doubles: <Vec<f64>>::new(),
+                                packed_floats: <Vec<f32>>::new(),
+                                packed_fixed32: <Vec<u32>>::new(),
+                                packed_fixed64: <Vec<u64>>::new(),
+                                packed_sfixed32: <Vec<i32>>::new(),
+                                packed_sfixed64: <Vec<i64>>::new(),
                             }
                         );
                     });
@@ -477,5 +543,138 @@ mod tests {
             err.contains("wire type mismatch"),
             "expected wire type mismatch error, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_decode_packed_fixed_types() {
+        let doubles = [1.0, -2.5, 3.14159];
+        let floats = [0.5f32, -1.0, 100.0];
+        let fixed32 = [0u32, 1, u32::MAX];
+        let fixed64 = [0u64, 1, u64::MAX];
+        let sfixed32 = [i32::MIN, 0, i32::MAX];
+        let sfixed64 = [i64::MIN, 0, i64::MAX];
+
+        // Encode with tacky
+        let mut buf = Vec::new();
+        let mut writer = SimpleMessage::new_writer(&mut buf, None);
+        tacky_macros::write_proto!(
+            writer,
+            SimpleMessage {
+                normal_int: None::<i64>,
+                zigzag_int: None::<i64>,
+                fixed_int: None::<i64>,
+                manynumbers: <Vec<i32>>::new(),
+                manynumbers_unpacked: <Vec<i32>>::new(),
+                packed_enum: <Vec<SimpleEnum>>::new(),
+                astring: None::<&str>,
+                manystrings: <Vec<&str>>::new(),
+                abytes: None::<&[u8]>,
+                manybytes: <Vec<&[u8]>>::new(),
+                yesno: None::<bool>,
+                packed_doubles: &doubles,
+                packed_floats: &floats,
+                packed_fixed32: &fixed32,
+                packed_fixed64: &fixed64,
+                packed_sfixed32: &sfixed32,
+                packed_sfixed64: &sfixed64,
+            }
+        );
+        drop(writer);
+
+        // Verify prost can decode it
+        let prost_msg = PSimpleMessage::decode(&*buf).unwrap();
+        assert_eq!(prost_msg.packed_doubles, doubles.to_vec());
+        assert_eq!(prost_msg.packed_floats, floats.to_vec());
+        assert_eq!(prost_msg.packed_fixed32, fixed32.to_vec());
+        assert_eq!(prost_msg.packed_fixed64, fixed64.to_vec());
+        assert_eq!(prost_msg.packed_sfixed32, sfixed32.to_vec());
+        assert_eq!(prost_msg.packed_sfixed64, sfixed64.to_vec());
+
+        // Decode with field enum
+        let mut remaining: &[u8] = &buf;
+        let mut decoded_doubles = Vec::new();
+        let mut decoded_floats = Vec::new();
+        let mut decoded_fixed32 = Vec::new();
+        let mut decoded_fixed64 = Vec::new();
+        let mut decoded_sfixed32 = Vec::new();
+        let mut decoded_sfixed64 = Vec::new();
+
+        while !remaining.is_empty() {
+            let Some(field) = SimpleMessageField::decode(&mut remaining).unwrap() else {
+                continue;
+            };
+            match field {
+                SimpleMessageField::PackedDoubles(iter) => {
+                    decoded_doubles.extend(iter.f64s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedFloats(iter) => {
+                    decoded_floats.extend(iter.f32s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedFixed32(iter) => {
+                    decoded_fixed32.extend(iter.u32s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedFixed64(iter) => {
+                    decoded_fixed64.extend(iter.u64s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedSfixed32(iter) => {
+                    decoded_sfixed32.extend(iter.i32s().map(|r| r.unwrap()));
+                }
+                SimpleMessageField::PackedSfixed64(iter) => {
+                    decoded_sfixed64.extend(iter.i64s().map(|r| r.unwrap()));
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(decoded_doubles, doubles.to_vec());
+        assert_eq!(decoded_floats, floats.to_vec());
+        assert_eq!(decoded_fixed32, fixed32.to_vec());
+        assert_eq!(decoded_fixed64, fixed64.to_vec());
+        assert_eq!(decoded_sfixed32, sfixed32.to_vec());
+        assert_eq!(decoded_sfixed64, sfixed64.to_vec());
+    }
+
+    #[test]
+    fn test_packed_iter_edge_cases() {
+        // Empty packed field - iterator yields nothing
+        let empty = tacky::PackedVarints(&[]);
+        assert_eq!(empty.count(), 0);
+
+        let empty_f32 = tacky::PackedFixed32s(&[]);
+        assert_eq!(empty_f32.count(), 0);
+
+        let empty_f64 = tacky::PackedFixed64s(&[]);
+        assert_eq!(empty_f64.count(), 0);
+
+        // Single element packed varint
+        let mut single_buf = Vec::new();
+        tacky::write_varint(42, &mut single_buf);
+        let single = tacky::PackedVarints(&single_buf);
+        let vals: Vec<u64> = single.map(|r| r.unwrap()).collect();
+        assert_eq!(vals, vec![42]);
+
+        // Single element packed fixed32
+        let bytes_f32 = 3.14f32.to_le_bytes();
+        let single_f32 = tacky::PackedFixed32s(&bytes_f32);
+        let vals: Vec<f32> = single_f32.f32s().map(|r| r.unwrap()).collect();
+        assert_eq!(vals, vec![3.14f32]);
+
+        // Single element packed fixed64
+        let bytes_f64 = 2.718f64.to_le_bytes();
+        let single_f64 = tacky::PackedFixed64s(&bytes_f64);
+        let vals: Vec<f64> = single_f64.f64s().map(|r| r.unwrap()).collect();
+        assert_eq!(vals, vec![2.718f64]);
+
+        // Truncated fixed32 should error
+        let truncated = tacky::PackedFixed32s(&[1, 2, 3]);
+        let results: Vec<_> = truncated.collect();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_err());
+
+        // Truncated fixed64 should error
+        let truncated = tacky::PackedFixed64s(&[1, 2, 3, 4, 5, 6, 7]);
+        let results: Vec<_> = truncated.collect();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_err());
     }
 }


### PR DESCRIPTION
Add decode support to tacky, making it no longer write-only. For each protobuf message, tacky-build now generates a typed `{Message}Field<'a>` enum that decodes wire data into Rust-typed variants. Users match on domain-level variants instead of dealing with field numbers, wire type checks, varint/length decoding, and manual buffer advancement.

The decode API operates on `&mut &'a [u8]` (not `&mut impl Buf`), which is the key to zero-copy borrowing — string and bytes variants borrow directly from the input buffer as `&'a str` and `&'a [u8]`.

Generated decode example:

```
  let mut remaining: &[u8] = &bytes;
  while !remaining.is_empty() {
      let Some(field) = MyMessageField::decode(&mut remaining)? else { continue };
      match field {
          MyMessageField::Name(s) => { /* s is &str */ }
          MyMessageField::Id(v) => { /* v is i64 */ }
          MyMessageField::Nested(raw) => { /* recursively decode raw */ }
      }
  }
```

Type mapping covers all protobuf scalar types, enums (as i32), messages and maps (as raw &[u8] for recursive decode), packed repeated (as raw &[u8] for user iteration), and non-packed repeated (yielded once per wire occurrence). The lifetime parameter is only included when the enum actually borrows from the buffer.

Files modified:
- src/scalars.rs — DecodeError enum, decode_varint, decode_key, decode_len, check_wire_type, skip_field, decode_zigzag32/64, and fixed-width decoders (decode_i32/u32/f32/i64/u64/f64)
- src/tack.rs — replace prost::encoding::decode_varint with own decode_varint in test
- Cargo.toml — remove prost from dev-dependencies
- Cargo.lock — updated lockfile
- tacky-build/src/field_enum.rs — new codegen module that generates the typed field enum and decode method per message
- tacky-build/src/lib.rs — register field_enum module
- tacky-build/src/parser.rs — call write_field_enum from write_simple_message
- testing/src/lib.rs — five new decode tests: roundtrip all scalar types, enum fields, recursive nested message decode, unknown field skipping, and wire type mismatch error