### PR TITLE
bugfixes

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -23,8 +23,12 @@ impl_wrapped!(Optional, Repeated, Required, Packed, Plain);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct OneOf<O>(PhantomData<O>);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct PbMap<K, V>(PhantomData<(K, V)>); // Map<PbString,Int32>
+impl<K, V> Copy for PbMap<K, V> {}
+impl<K, V> Clone for PbMap<K, V> {
+    fn clone(&self) -> Self { *self }
+}
 
 //field labels/modifiers that can be applied to the above (except maps and oneOfs)
 
@@ -39,8 +43,8 @@ impl<const N: u32, P> Field<N, P> {
 
 pub mod optional {
     use super::*;
-    impl<'b, const N: u32, P: ProtobufScalar> Field<N, Optional<P>> {
-        pub fn write<V: ProtoEncode<P>>(&self, buf: &'b mut Vec<u8>, value: Option<V>) -> Self {
+    impl<const N: u32, P: ProtobufScalar> Field<N, Optional<P>> {
+        pub fn write<V: ProtoEncode<P>>(self, buf: &mut Vec<u8>, value: Option<V>) -> Self {
             if let Some(value) = value {
                 <V as ProtoEncode<P>>::encode(buf, N, &value);
             }
@@ -48,8 +52,8 @@ pub mod optional {
         }
     }
 
-    impl<'b, const N: u32, M: MessageSchema> Field<N, Optional<M>> {
-        pub fn write_msg(&self, buf: &'b mut Vec<u8>, mut f: impl FnMut(&mut Vec<u8>, M)) -> Self {
+    impl<const N: u32, M: MessageSchema> Field<N, Optional<M>> {
+        pub fn write_msg(self, buf: &mut Vec<u8>, mut f: impl FnMut(&mut Vec<u8>, M)) -> Self {
             let t = Tack::new(buf, N); // reserve space for tag and length
             f(t.buffer, M::default());
             Field::new()
@@ -72,14 +76,14 @@ pub mod repeated {
             Field::new()
         }
         #[inline]
-        pub fn write_single<V: ProtoEncode<P>>(&self, buf: &mut Vec<u8>, value: V) -> Self {
+        pub fn write_single<V: ProtoEncode<P>>(self, buf: &mut Vec<u8>, value: V) -> Self {
             <V as ProtoEncode<P>>::encode(buf, N, &value);
             Field::new()
         }
     }
 
-    impl<'b, const N: u32, M: MessageSchema> Field<N, Repeated<M>> {
-        pub fn write_msg(&self, buf: &'b mut Vec<u8>, mut f: impl FnMut(&mut Vec<u8>, M)) -> Self {
+    impl<const N: u32, M: MessageSchema> Field<N, Repeated<M>> {
+        pub fn write_msg(self, buf: &mut Vec<u8>, mut f: impl FnMut(&mut Vec<u8>, M)) -> Self {
             let t = Tack::new(buf, N); // reserve space for tag and length
             f(t.buffer, M::default());
             Field::new()
@@ -213,8 +217,8 @@ impl<K: ProtobufScalar, M: MessageSchema> PbMap<K, M> {
                     let msg_buf = decode_len(&mut entry_buf)?;
                     val = Some(decoder(&msg_buf));
                 }
-                _ => {
-                    return Err(DecodeError::InvalidMapEntry);
+                (_, wt) => {
+                    skip_field(wt, &mut entry_buf)?;
                 }
             }
         }
@@ -245,8 +249,8 @@ impl<K: ProtobufScalar, V: ProtobufScalar> PbMap<K, V> {
                     check_wire_type(wt, V::WIRE_TYPE, "value")?;
                     val = Some(V::read(&mut entry_buf)?);
                 }
-                _ => {
-                    return Err(DecodeError::InvalidMapEntry);
+                (_, wt) => {
+                    skip_field(wt, &mut entry_buf)?;
                 }
             }
         }
@@ -261,7 +265,7 @@ pub mod maps {
     use super::*;
     impl<const N: u32, K: ProtobufScalar, V: ProtobufScalar> Field<N, PbMap<K, V>> {
         pub fn write<I: IntoIterator<Item = (A, B)>, A: ProtoEncode<K>, B: ProtoEncode<V>>(
-            &self,
+            self,
             buf: &mut Vec<u8>,
             values: I,
         ) -> Field<N, PbMap<K, V>> {
@@ -272,7 +276,7 @@ pub mod maps {
         }
         // writing {key; none} is useful as a way to delete entries in an update message
         pub fn write_entry<A: ProtoEncode<K>, B: ProtoEncode<V>>(
-            &self,
+            self,
             buf: &mut Vec<u8>,
             key: A,
             value: Option<B>,
@@ -293,7 +297,7 @@ pub mod maps {
     }
     impl<const N: u32, K: ProtobufScalar, M: MessageSchema> Field<N, PbMap<K, M>> {
         pub fn write_msg<A: ProtoEncode<K>>(
-            &self,
+            self,
             buf: &mut Vec<u8>,
             key: A,
             mut value: impl FnMut(&mut Vec<u8>, M),

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -599,7 +599,7 @@ pub fn decode_varint(buf: &mut &[u8]) -> Result<u64, DecodeError> {
 
 #[inline]
 pub fn skip_varint(buf: &mut &[u8]) -> Result<(), DecodeError> {
-    if buf.len() >= 8 {
+    if buf.len() >= 10 {
         let word = u64::from_le_bytes(buf[..8].try_into().unwrap());
         let msbs = !word & 0x8080808080808080;
         if msbs != 0 {
@@ -623,6 +623,53 @@ pub fn skip_varint(buf: &mut &[u8]) -> Result<(), DecodeError> {
         .ok_or(DecodeError::Truncated)?;
     *buf = &buf[len..];
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skip_varint_panics_on_8_byte_buffer() {
+        // 8 bytes, all with continuation bit set — a truncated varint.
+        // This should return Truncated, not panic on out-of-bounds buf[8].
+        let data = [0x80u8; 8];
+        let mut buf: &[u8] = &data;
+        let result = skip_varint(&mut buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_skip_varint_panics_on_9_byte_buffer() {
+        // 9 bytes, all with continuation bit set — a truncated varint.
+        // This should return Truncated, not panic on out-of-bounds buf[9].
+        let data = [0x80u8; 9];
+        let mut buf: &[u8] = &data;
+        let result = skip_varint(&mut buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_skip_varint_9_byte_valid() {
+        // 8 continuation bytes + 1 terminating byte = valid 9-byte varint
+        let mut data = [0x80u8; 9];
+        data[8] = 0x01; // terminating byte
+        let mut buf: &[u8] = &data;
+        let result = skip_varint(&mut buf);
+        assert!(result.is_ok());
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_skip_varint_10_byte_valid() {
+        // 9 continuation bytes + 1 terminating byte = valid 10-byte varint (max)
+        let mut data = [0x80u8; 10];
+        data[9] = 0x01;
+        let mut buf: &[u8] = &data;
+        let result = skip_varint(&mut buf);
+        assert!(result.is_ok());
+        assert!(buf.is_empty());
+    }
 }
 
 /// Decode a length-delimited field, returning a sub-slice of the input.

--- a/tacky-build/src/field_enum.rs
+++ b/tacky-build/src/field_enum.rs
@@ -224,14 +224,12 @@ pub fn field_enum(name: &str, fields: &[Field]) -> TokenStream {
 
             quote! {
                 #tag => {
-                    Some((
+                    return Some((
                         || {
                          tacky::check_wire_type(wire_type, #wt, #field_name_str)?;
                     #decode
                     Ok(#enum_name::#variant_name(#value))
                     })())
-
-
                 }
             }
         })
@@ -264,22 +262,23 @@ pub fn field_enum(name: &str, fields: &[Field]) -> TokenStream {
             type Item = Result<#enum_name #lt_token, tacky::DecodeError>;
 
             fn next(&mut self) -> Option<Self::Item> {
-                if self.buf.is_empty() {
-                    return None;
-                }
-                let buf = &mut self.buf;
-                let (tag, wire_type) = match tacky::decode_key(buf) {
-                    Ok(t) => t,
-                    Err(e) => return Some(Err(e)),
-                };
-                match tag {
-                    #(#match_arms)*
-                    _ => {
-                        match tacky::skip_field(wire_type, buf) {
-                            Ok(()) => Self::next(self), // recursively call next to find the next known field
-                            Err(e) => Some(Err(e)),
+                loop {
+                    if self.buf.is_empty() {
+                        return None;
+                    }
+                    let buf = &mut self.buf;
+                    let (tag, wire_type) = match tacky::decode_key(buf) {
+                        Ok(t) => t,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    match tag {
+                        #(#match_arms)*
+                        _ => {
+                            match tacky::skip_field(wire_type, buf) {
+                                Ok(()) => continue,
+                                Err(e) => return Some(Err(e)),
+                            }
                         }
-
                     }
                 }
             }


### PR DESCRIPTION
- aligned all the writers so they all take self rather than a mix of &self/self.
- potential panic in skip_varint fixed
- theoretical stack overflow because of the recursive `decode` function fixed