### PR TITLE
Microoptimize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "tacky"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,15 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
@@ -239,6 +245,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -266,7 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -391,11 +406,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -448,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -458,16 +474,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "bytes",
  "heck",
  "itertools 0.12.1",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
@@ -479,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -492,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tacky"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A protobuf serializer and deserializer for Rust that gets out of the way of your domain types.
 
-Note: this is work-in-progress, APIs may change. the basic idea will not.
+Note: this is work-in-progress, APIs may change. The basic idea will not.
 
 ## Why this exists
 
@@ -50,7 +50,7 @@ schema.numbers.write(&mut buffer, [1, 2, 3, 4]);
 
 ## Exhaustiveness Checking
 
-The usual assumption is that skipping the generated struct means losing safety — forget to write a field and nothing tells you. Tacky sidesteps this with a small trick: every `.write()` call returns the field schema value back. This means you can use the generated schema as a literal to "fill in". and get compile-time exhaustiveness for free:
+The usual assumption is that skipping the generated struct means losing safety — forget to write a field and nothing tells you. Tacky sidesteps this with a small trick: every `.write()` call returns the field schema value back. This means you can use the generated schema as a literal to "fill in" and get compile-time exhaustiveness for free:
 
 ```rust
 let mut buffer = Vec::new();
@@ -94,52 +94,53 @@ schema.events.write_msg(&mut buf, |buf, scm| {
         name: scm.name.write(buf, Some("scroll")),
         ..scm
     }
-}
+});
 ```
-// ---- OR ----
+
+Or, if you're writing from a collection:
+
 ```rust
 let events = ["scroll", "click"];
 Message {
     events: {
         for e in events {
             schema.events.write_msg(&mut buf, |buf, scm| {
-            EventSchema {
-                name: scm.name.write(buf, Some(e)),
-                ..scm
-            }}
+                EventSchema {
+                    name: scm.name.write(buf, Some(e)),
+                    ..scm
+                }
+            });
         }
-        schema.events //gotta mark this as written explicitly as a for loop returns (), not the written field. 
-        },
-        ..Message::default()
-}
-
+        schema.events // mark as written; a for loop returns (), not the field
+    },
+    ..Message::default()
+};
 ```
 
 ## Performance
 
 Protobuf has two cases where the length of a field must be written before its contents — packed repeated fields and nested messages. The conventional approach is two passes: iterate to calculate the length, write the length, then iterate again to write the data.
 
-Tacky instead writes a placeholder length, writes the data in a single pass, and patches the real length in place when the scope closes. This applies to both packed fields and nested messages. for varints this is much faster. 
-prost wants to allocate a vec for both repeated and packed values, the calculating the length of this vec in the repeat unpacked case where the tag length needs to be calculated as well results in particularly bad performance.
+Tacky instead writes a placeholder length, writes the data in a single pass, and patches the real length in place when the scope closes. This applies to both packed fields and nested messages. For varints this is much faster. Prost wants to allocate a Vec for both repeated and packed values; calculating the length of this Vec in the unpacked repeated case where the tag length also needs to be calculated results in particularly bad performance.
 
 
 | Benchmark Suite | Variant | Tacky Time | Prost Time | Performance Difference |
 | :--- | :--- | :--- | :--- | :--- |
-| **Tiny nested Messages** | Default | ~29 ns | ~26 ns | Prost is ~1.1x faster |
-| **Big Nested Messages** | Default | ~35 ns | ~80 ns | Tacky is ~2.3x faster |
-| **Packed Repeated** | Few (10) | ~36 ns | ~52 ns | Tacky is ~1.4x faster |
-| **Packed Repeated** | Many (100) | ~363 ns | ~565 ns | Tacky is ~1.5x faster |
-| **Packed Repeated** | Hundreds (1000) | ~3.80 µs| ~5.51 µs | Tacky is ~1.4x faster |
-| **Normal Repeated** | Few (10) | ~26 ns | ~62 ns | Tacky is ~2.4x faster |
-| **Normal Repeated** | Many (100) | ~281 ns | ~618 ns | Tacky is ~2.2x faster |
-| **Normal Repeated** | Hundreds (1000) | ~2.57 µs | ~6.58 µs | Tacky is ~2.5x faster |
-| **Mixed Usage** | All fields set | ~121 ns | ~187 ns | Tacky is ~1.5x faster |
-| **Mixed Usage** | Half fields set | ~60 ns | ~87 ns | Tacky is ~1.4x faster |
-| **Mixed Usage** | Few fields set (1-2) | ~1.7 ns | ~12.1 ns | Tacky is ~7.1x faster |
+| **Tiny nested Messages** | Default | ~26 ns | ~27 ns | Tacky is ~1.04x faster |
+| **Big Nested Messages** | Default | ~33 ns | ~80 ns | Tacky is ~2.5x faster |
+| **Packed Repeated** | Few (10) | ~33 ns | ~49 ns | Tacky is ~1.5x faster |
+| **Packed Repeated** | Many (100) | ~309 ns | ~568 ns | Tacky is ~1.8x faster |
+| **Packed Repeated** | Hundreds (1000) | ~3.62 µs| ~5.73 µs | Tacky is ~1.6x faster |
+| **Normal Repeated** | Few (10) | ~25 ns | ~64 ns | Tacky is ~2.5x faster |
+| **Normal Repeated** | Many (100) | ~282 ns | ~615 ns | Tacky is ~2.2x faster |
+| **Normal Repeated** | Hundreds (1000) | ~2.57 µs | ~6.54 µs | Tacky is ~2.5x faster |
+| **Mixed Usage** | All fields set | ~94 ns | ~172 ns | Tacky is ~1.8x faster |
+| **Mixed Usage** | Half fields set | ~47 ns | ~89 ns | Tacky is ~1.9x faster |
+| **Mixed Usage** | Few fields set (1-2) | ~1.6 ns | ~12.2 ns | Tacky is ~7.6x faster |
 
 ## Deserialization
 
-`tacky-build` generates an enum with a variant per field, and an iterator that yields them one at a time. You match on variants and build your domain object from primitives. you can either exhaustively match all the fields or just select what you care about at this point. unknown fields are skipped by the iterator. if you need to keep unknown fields, let me know.
+`tacky-build` generates an enum with a variant per field, and an iterator that yields them one at a time. You match on variants and build your domain object from primitives. You can either exhaustively match all the fields or just select what you care about. Unknown fields are skipped by the iterator.
 
 ```rust
 for field in SimpleMessageDecoder::new(&buf) {
@@ -151,7 +152,7 @@ for field in SimpleMessageDecoder::new(&buf) {
 }
 ```
 
-Fields come back as basic Rust primitives — `&str`, `i32`, `f64`, etc. Mapping those to your domain types is up to you. Only one enum variant lives on the stack at a time, regardless of how many fields the message has. the struct approach prost and co use can lead to just the size on the stack of the message before any data is filled in to be much larger than the message itself, and grows with more fields.
+Fields come back as basic Rust primitives — `&str`, `i32`, `f64`, etc. Mapping those to your domain types is up to you. Only one enum variant lives on the stack at a time, regardless of how many fields the message has. The struct approach that prost and others use can lead to the stack size of the message alone being much larger than the serialized data, and it grows with every field.
 
 
 ## Limitations
@@ -159,8 +160,8 @@ Fields come back as basic Rust primitives — `&str`, `i32`, `f64`, etc. Mapping
 **Imports and nested definitions are not yet supported.** 
 All message definitions must be flat within a single file.
 
-**protobuf merge semantics dont work**
-Due to the design of the deserializer as a-field-at-a-time, it doesnt automatically merge repeated instances of a "singular" messages. if that is required for correctness in your case, you can implement it in your code.
+**Protobuf merge semantics don't work.**
+Due to the design of the deserializer as a-field-at-a-time, it doesn't automatically merge repeated instances of a singular message. If that is required for correctness in your case, you can implement it in your code.
 
 **OneOf fields are flattened into the schema.** For a serializer this is fine — the OneOf constraint is more meaningful during deserialization. If you need to enforce OneOf semantics you'll need to do that in your own code.
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -4,6 +4,7 @@ use bytes::Buf;
 
 use crate::{scalars::*, tack::Tack};
 use std::marker::PhantomData;
+
 macro_rules! impl_wrapped {
     ($($t:ident),*) => {
         $(
@@ -27,7 +28,9 @@ pub struct OneOf<O>(PhantomData<O>);
 pub struct PbMap<K, V>(PhantomData<(K, V)>); // Map<PbString,Int32>
 impl<K, V> Copy for PbMap<K, V> {}
 impl<K, V> Clone for PbMap<K, V> {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 //field labels/modifiers that can be applied to the above (except maps and oneOfs)
@@ -46,7 +49,9 @@ pub mod optional {
     impl<const N: u32, P: ProtobufScalar> Field<N, Optional<P>> {
         pub fn write<V: ProtoEncode<P>>(self, buf: &mut Vec<u8>, value: Option<V>) -> Self {
             if let Some(value) = value {
-                <V as ProtoEncode<P>>::encode(buf, N, &value);
+                let t = const { EncodedTag::new(N, P::WIRE_TYPE) };
+                t.write(buf);
+                P::write_value(value.as_scalar(), buf);
             }
             Field::new()
         }
@@ -54,7 +59,9 @@ pub mod optional {
 
     impl<const N: u32, M: MessageSchema> Field<N, Optional<M>> {
         pub fn write_msg(self, buf: &mut Vec<u8>, mut f: impl FnMut(&mut Vec<u8>, M)) -> Self {
-            let t = Tack::new(buf, N); // reserve space for tag and length
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+            let t = Tack::new(buf);
             f(t.buffer, M::default());
             Field::new()
         }
@@ -70,21 +77,27 @@ pub mod repeated {
             buf: &mut Vec<u8>,
             values: impl IntoIterator<Item = V>,
         ) -> Field<N, Repeated<P>> {
+            let t = const { EncodedTag::new(N, P::WIRE_TYPE) };
             for value in values {
-                <V as ProtoEncode<P>>::encode(buf, N, &value);
+                t.write(buf);
+                P::write_value(value.as_scalar(), buf);
             }
             Field::new()
         }
         #[inline]
         pub fn write_single<V: ProtoEncode<P>>(self, buf: &mut Vec<u8>, value: V) -> Self {
-            <V as ProtoEncode<P>>::encode(buf, N, &value);
+            let t = const { EncodedTag::new(N, P::WIRE_TYPE) };
+            t.write(buf);
+            P::write_value(value.as_scalar(), buf);
             Field::new()
         }
     }
 
     impl<const N: u32, M: MessageSchema> Field<N, Repeated<M>> {
         pub fn write_msg(self, buf: &mut Vec<u8>, mut f: impl FnMut(&mut Vec<u8>, M)) -> Self {
-            let t = Tack::new(buf, N); // reserve space for tag and length
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+            let t = Tack::new(buf);
             f(t.buffer, M::default());
             Field::new()
         }
@@ -100,12 +113,46 @@ pub mod packed {
             buf: &mut Vec<u8>,
             values: impl IntoIterator<Item = V>,
         ) -> Field<N, Packed<P>> {
-            let it = values.into_iter();
-            // room for 16k bytes. if the packed field exceeds that, it'll just reallocate and write again.
-            let t = Tack::new_with_width(buf, N, 2);
-            for value in it {
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+            let t = Tack::new_with_width(buf, 2);
+            for value in values {
                 let value = value.as_scalar();
                 P::write_value(value, t.buffer);
+            }
+            Field::new()
+        }
+
+        /// Like `write`, but requires an ExactSizeIterator. For fixed-size types (float, double,
+        /// fixed32, fixed64, sfixed32, sfixed64), this bypasses the Tack and writes the length
+        /// prefix directly, which is significantly faster.
+        #[inline]
+        pub fn write_exact<I>(self, buf: &mut Vec<u8>, values: I) -> Field<N, Packed<P>>
+        where
+            I: IntoIterator<Item: ProtoEncode<P>>,
+            I::IntoIter: ExactSizeIterator,
+        {
+            let it = values.into_iter();
+            if let Some(fixed_size) = P::FIXED_WIRE_SIZE {
+                let count = it.len();
+                if count == 0 {
+                    return Field::new();
+                }
+                let data_len = count * fixed_size;
+                let tag = const { EncodedTag::new(N, WireType::LEN) };
+                tag.write(buf);
+                write_varint(data_len as u64, buf);
+                for value in it {
+                    P::write_value(value.as_scalar(), buf);
+                }
+                return Field::new();
+            }
+            // Varint types: still need Tack since encoded size depends on values
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+            let t = Tack::new_with_width(buf, 2);
+            for value in it {
+                P::write_value(value.as_scalar(), t.buffer);
             }
             Field::new()
         }
@@ -149,7 +196,9 @@ pub mod required {
             buf: &mut Vec<u8>,
             value: V,
         ) -> Field<N, Required<P>> {
-            <V as ProtoEncode<P>>::encode(buf, N, &value);
+            let t = const { EncodedTag::new(N, P::WIRE_TYPE) };
+            t.write(buf);
+            P::write_value(value.as_scalar(), buf);
             Field::new()
         }
     }
@@ -160,7 +209,9 @@ pub mod required {
             buf: &mut Vec<u8>,
             mut func: impl FnMut(&mut Vec<u8>, M),
         ) -> Field<N, Required<M>> {
-            let t = Tack::new(buf, N);
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+            let t = Tack::new(buf);
             func(t.buffer, M::default());
             Field::new()
         }
@@ -175,7 +226,9 @@ pub mod plain {
             if value.is_default() {
                 return Field::new();
             }
-            <V as ProtoEncode<P>>::encode(buf, N, &value);
+            let t = const { EncodedTag::new(N, P::WIRE_TYPE) };
+            t.write(buf);
+            P::write_value(value.as_scalar(), buf);
             Field::new()
         }
     }
@@ -185,7 +238,9 @@ pub mod plain {
             buf: &mut Vec<u8>,
             mut func: impl FnMut(&mut Vec<u8>, M),
         ) -> Field<N, Plain<M>> {
-            let t = Tack::new(buf, N);
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+            let t = Tack::new(buf);
             func(t.buffer, M::default());
             Field::new()
         }
@@ -282,15 +337,22 @@ pub mod maps {
             value: Option<B>,
         ) -> Field<N, PbMap<K, V>> {
             // the tag and wire type for the map field itself
-            write_varint((N << 3 | 2) as u64, buf);
+            let t = const { EncodedTag::new(N, WireType::LEN) };
+            t.write(buf);
+
             let k = key.as_scalar();
             let v = value.as_ref().map(|v| v.as_scalar());
             // len of the entry message, which is 1 (for the key) + len of the key + (0 if value is None else 1 + len of value)
             let len = K::len(1, k) + v.map(|v| V::len(1, v)).unwrap_or(0);
             write_varint(len as u64, buf);
-            A::encode(buf, 1, &key);
+            let t = const { EncodedTag::new(1, K::WIRE_TYPE) };
+            t.write(buf);
+
+            A::encode(buf, &key);
             if let Some(value) = value {
-                B::encode(buf, 2, &value);
+                let t = const { EncodedTag::new(2, V::WIRE_TYPE) };
+                t.write(buf);
+                B::encode(buf, &value);
             }
             Field::new()
         }
@@ -302,10 +364,16 @@ pub mod maps {
             key: A,
             mut value: impl FnMut(&mut Vec<u8>, M),
         ) -> Field<N, PbMap<K, M>> {
-            let t = Tack::new_with_width(buf, N, 2);
-            A::encode(t.buffer, 1, &key);
+            let tag = const { EncodedTag::new(N, WireType::LEN) };
+            tag.write(buf);
+            let t = Tack::new_with_width(buf, 2);
+            let tag = const { EncodedTag::new(1, K::WIRE_TYPE) };
+            tag.write(t.buffer);
+            A::encode(t.buffer, &key);
             {
-                let tt = Tack::new_with_width(t.buffer, 2, 2);
+                let tag = const { EncodedTag::new(2, WireType::LEN) };
+                tag.write(t.buffer);
+                let tt = Tack::new_with_width(t.buffer, 2);
                 value(tt.buffer, M::default());
             }
             Field::new()
@@ -331,11 +399,9 @@ pub trait ProtoEncode<P: ProtobufScalar> {
     fn is_default(&self) -> bool {
         self.as_scalar() == P::RustType::default()
     }
-
     /// default implementation of encode, which works for all types that can be converted to protobuf scalars.
     /// if your type cant be converted to the protobuf scalar type, you can implement encode directly.
-    fn encode(buf: &mut Vec<u8>, field_nr: u32, value: &Self) {
-        P::write_tag(field_nr, buf);
+    fn encode(buf: &mut Vec<u8>, value: &Self) {
         let value = value.as_scalar();
         P::write_value(value, buf);
     }

--- a/src/scalars.rs
+++ b/src/scalars.rs
@@ -38,6 +38,8 @@ pub struct PbEnum<T>(PhantomData<T>);
 pub trait ProtobufScalar {
     type RustType<'a>: Copy + Default + PartialEq;
     const WIRE_TYPE: WireType;
+    /// For fixed-size wire types, the encoded size per element. None for varints.
+    const FIXED_WIRE_SIZE: Option<usize> = None;
     /// how to write the value itself.
     /// can also be used to write the value without tag.
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut);
@@ -233,6 +235,7 @@ impl ProtobufScalar for Bool {
 impl ProtobufScalar for Fixed32 {
     type RustType<'a> = u32;
     const WIRE_TYPE: WireType = WireType::I32;
+    const FIXED_WIRE_SIZE: Option<usize> = Some(4);
 
     #[inline]
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut) {
@@ -258,6 +261,7 @@ impl ProtobufScalar for Fixed32 {
 impl ProtobufScalar for Sfixed32 {
     type RustType<'a> = i32;
     const WIRE_TYPE: WireType = WireType::I32;
+    const FIXED_WIRE_SIZE: Option<usize> = Some(4);
 
     #[inline]
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut) {
@@ -283,6 +287,7 @@ impl ProtobufScalar for Sfixed32 {
 impl ProtobufScalar for Float {
     type RustType<'a> = f32;
     const WIRE_TYPE: WireType = WireType::I32;
+    const FIXED_WIRE_SIZE: Option<usize> = Some(4);
 
     #[inline]
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut) {
@@ -308,6 +313,7 @@ impl ProtobufScalar for Float {
 impl ProtobufScalar for Fixed64 {
     type RustType<'a> = u64;
     const WIRE_TYPE: WireType = WireType::I64;
+    const FIXED_WIRE_SIZE: Option<usize> = Some(8);
 
     #[inline]
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut) {
@@ -333,6 +339,7 @@ impl ProtobufScalar for Fixed64 {
 impl ProtobufScalar for Sfixed64 {
     type RustType<'a> = i64;
     const WIRE_TYPE: WireType = WireType::I64;
+    const FIXED_WIRE_SIZE: Option<usize> = Some(8);
 
     #[inline]
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut) {
@@ -358,6 +365,7 @@ impl ProtobufScalar for Sfixed64 {
 impl ProtobufScalar for Double {
     type RustType<'a> = f64;
     const WIRE_TYPE: WireType = WireType::I64;
+    const FIXED_WIRE_SIZE: Option<usize> = Some(8);
 
     #[inline]
     fn write_value(value: Self::RustType<'_>, buf: &mut impl BufMut) {
@@ -669,6 +677,42 @@ mod tests {
         let result = skip_varint(&mut buf);
         assert!(result.is_ok());
         assert!(buf.is_empty());
+    }
+}
+
+/// Precomputed varint-encoded tag (field number + wire type).
+/// Since field numbers are typically small (1-2 bytes encoded), this avoids
+/// running the varint encoding loop on every element in a repeated field.
+pub struct EncodedTag {
+    pub bytes: [u8; 5], // max 5 bytes for a 32-bit tag varint
+    pub len: u8,
+}
+
+impl EncodedTag {
+    #[inline]
+    pub const fn new(field_nr: u32, wire_type: WireType) -> Self {
+        let mut tag = (field_nr << 3) | (wire_type as u32);
+        let mut bytes = [0u8; 5];
+        let mut i = 0;
+        loop {
+            if tag < 0x80 {
+                bytes[i] = tag as u8;
+                i += 1;
+                break;
+            }
+            bytes[i] = ((tag & 0x7F) | 0x80) as u8;
+            tag >>= 7;
+            i += 1;
+        }
+        EncodedTag {
+            bytes,
+            len: i as u8,
+        }
+    }
+
+    #[inline]
+    pub fn write(&self, buf: &mut impl BufMut) {
+        buf.put_slice(&self.bytes[..self.len as usize]);
     }
 }
 

--- a/src/tack.rs
+++ b/src/tack.rs
@@ -1,25 +1,21 @@
 //! A Tack marks the start of a as-of-yet unknown length delimited quantity.
-//! upon creation, it writes down the tag of thie field and a (configurable)fixed width length field.
+//! upon creation, it writes a (configurable) fixed width length field.
 //! Once this struct Drop's, it goes back and updates the length field with however much was written to the buffer in the mean time.
-//! Since the length field is fixed width (by default 4 bytes, which allows for messages of size 2**28 -1 bits long.) it can in theory overflow.
+//! Since the length field is fixed width (by default 3 bytes, which allows for messages of size ~2Mb.) it can in theory overflow.
 //! if that happens, the Tack will reallocate the buffer to make room for a larger length field, and shift the data over to make room for it, before writing the length.
+//! The caller is responsible for writing the tag before creating the Tack.
 
 use crate::scalars::{self, encoded_len_varint};
 use bytes::BufMut;
-use std::num::NonZeroU32;
 /// A Tack marks the start of a as-of-yet unknown length delimited quantity.
 #[must_use]
 pub struct Tack<'b> {
     pub buffer: &'b mut Vec<u8>,
-    // if the length of data written is 0, controls if the buffer is rewound to before the tag, or keeps the tag and len of 0.
-    // default true
-    pub rewind: bool,
-    pub tag: NonZeroU32,
     start: u32,
     width: u32,
 }
 
-fn write_wide_varint(width: usize, value: u64, buf: &mut impl BufMut) {
+pub fn write_wide_varint(width: usize, value: u64, buf: &mut impl BufMut) {
     assert!(width <= 5 && width > 0);
     assert!(value < 2u64.pow(7 * width as u32));
     if width == 1 {
@@ -33,26 +29,19 @@ fn write_wide_varint(width: usize, value: u64, buf: &mut impl BufMut) {
 }
 
 impl<'b> Tack<'b> {
-    /// creates a new tack, which marks the start of a length-delimited field of TBD length.
-    /// takes a buffer, and an optional tag. for top level messages, this will be None, as they dont have a tag or length delimiter of their own.
-    pub fn new(buffer: &'b mut Vec<u8>, field_nr: u32) -> Self {
-        // default to 3 bytes width for the length field, which allows for messages of ~2Mb in size,
-        //which should be enough for most use cases, while keeping the overhead low for small messages.
-        Self::new_with_width(buffer, field_nr, 3)
+    /// Creates a new tack, which marks the start of a length-delimited section of TBD length.
+    /// The caller must write the tag before creating the Tack.
+    /// Defaults to 3 bytes width for the length field (~2Mb max).
+    pub fn new(buffer: &'b mut Vec<u8>) -> Self {
+        Self::new_with_width(buffer, 3)
     }
-    pub fn new_with_width(buffer: &'b mut Vec<u8>, field_nr: u32, width: u32) -> Self {
-        let tag = (field_nr << 3) | 2;
-        let tag = NonZeroU32::new(tag).expect("Protobuf field nr may not be 0");
-        scalars::write_varint(tag.get() as u64, buffer);
+    pub fn new_with_width(buffer: &'b mut Vec<u8>, width: u32) -> Self {
         // since we dont know the length yet, we write a prelim <width> bytes wide varint, and fix it later
         write_wide_varint(width as usize, 0, buffer);
 
-        // now start represents the actual start of the data buffer, excluding the tag/length prefix
         Tack {
             start: buffer.len() as u32,
             buffer,
-            rewind: true,
-            tag,
             width,
         }
     }
@@ -61,15 +50,6 @@ impl<'b> Tack<'b> {
         let start = self.start as usize;
         let width = self.width as usize;
         let data_len = self.buffer.len() - start;
-
-        // Data is 0, handle rewind
-        if data_len == 0 {
-            if self.rewind {
-                let tag_len = encoded_len_varint(self.tag.get() as u64);
-                self.buffer.truncate(start - (tag_len + width));
-            }
-            return;
-        }
 
         let required_width = encoded_len_varint(data_len as u64);
 
@@ -105,6 +85,7 @@ impl<'b> Drop for Tack<'b> {
         self.close()
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -147,14 +128,16 @@ mod tests {
     #[test]
     fn test_tack_expansion() {
         let mut buf = Vec::new();
+        // Manually write the tag (field 1, wire type LEN = 0x0A)
+        crate::scalars::write_varint(0x0A, &mut buf);
         {
-            let t = crate::tack::Tack::new_with_width(&mut buf, 1, 1);
+            let t = crate::tack::Tack::new_with_width(&mut buf, 1);
             // Write 150 bytes of data (requires 2 bytes for length varint, taking up width=1 and expanding by 1)
             for _ in 0..150 {
                 t.buffer.push(0xAA);
             }
         }
-        // Expected layout: tag (1 byte: field 1, wire type 2 = 0x0A), len (2 bytes: 150 = 0x96 0x01), data (150 bytes of 0xAA)
+        // Expected layout: tag (1 byte: 0x0A), len (2 bytes: 150 = 0x96 0x01), data (150 bytes of 0xAA)
         assert_eq!(buf.len(), 1 + 2 + 150);
         assert_eq!(buf[0], 0x0A);
         assert_eq!(buf[1], 0x96);

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 tacky = { path = "../" }
-prost = "0.12"
+prost = "0.14"
 [build-dependencies]
-prost-build = "0.12"
+prost-build = "0.14"
 tacky-build = { path = "../tacky-build" }
 
 [dev-dependencies]
@@ -17,4 +17,8 @@ criterion = "0.5"
 
 [[bench]]
 name = "benchmark"
+harness = false
+
+[[bench]]
+name = "microbench"
 harness = false

--- a/testing/benches/benchmark.rs
+++ b/testing/benches/benchmark.rs
@@ -63,6 +63,8 @@ fn bench_packed_repeated(c: &mut Criterion) {
                 packed_fixed64: vec![],
                 packed_sfixed32: vec![],
                 packed_sfixed64: vec![],
+                repeated_ints: vec![],
+                repeated_floats: vec![],
             };
             let mut buf = Vec::with_capacity(1024 * 10);
             b.iter(|| {
@@ -115,6 +117,8 @@ fn bench_normal_repeated(c: &mut Criterion) {
                 packed_fixed64: vec![],
                 packed_sfixed32: vec![],
                 packed_sfixed64: vec![],
+                repeated_ints: vec![],
+                repeated_floats: vec![],
             };
             let mut buf = Vec::with_capacity(1024 * 10);
             b.iter(|| {

--- a/testing/benches/microbench.rs
+++ b/testing/benches/microbench.rs
@@ -1,0 +1,153 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+// ──────────────────────────────────────────────────
+//  packed fields: tacky vs prost (fixed + varint, short + medium)
+// ──────────────────────────────────────────────────
+fn bench_packed_vs_prost(c: &mut Criterion) {
+    use prost::Message;
+    let mut group = c.benchmark_group("packed_vs_prost");
+
+    let sizes: &[(&str, usize)] = &[("3", 3), ("20", 20), ("50", 50)];
+
+    for (name, count) in sizes {
+        let ints: Vec<i32> = (0..*count as i32).map(|i| i * 137).collect();
+        let floats: Vec<f32> = (0..*count).map(|i| i as f32 * 0.5).collect();
+        let doubles: Vec<f64> = (0..*count).map(|i| i as f64 * 0.5).collect();
+        let fixed32s: Vec<u32> = (0..*count as u32).map(|i| i * 7).collect();
+        let fixed64s: Vec<u64> = (0..*count as u64).map(|i| i * 7).collect();
+
+        // --- packed varint (Int32) ---
+        group.bench_function(format!("tacky_varint_{name}"), |b| {
+            use tacky_proto::example::SimpleMessage as TSimpleMessage;
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                let schema = TSimpleMessage::default();
+                schema.manynumbers.write(&mut buf, &ints);
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+        group.bench_function(format!("prost_varint_{name}"), |b| {
+            let msg = prost_proto::SimpleMessage {
+                manynumbers: ints.clone(),
+                ..Default::default()
+            };
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                msg.encode(&mut buf).unwrap();
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+
+        // --- packed float ---
+        group.bench_function(format!("tacky_float_{name}"), |b| {
+            use tacky_proto::example::SimpleMessage as TSimpleMessage;
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                let schema = TSimpleMessage::default();
+                schema.packed_floats.write_exact(&mut buf, &floats);
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+        group.bench_function(format!("prost_float_{name}"), |b| {
+            let msg = prost_proto::SimpleMessage {
+                packed_floats: floats.clone(),
+                ..Default::default()
+            };
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                msg.encode(&mut buf).unwrap();
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+
+        // --- packed double ---
+        group.bench_function(format!("tacky_double_{name}"), |b| {
+            use tacky_proto::example::SimpleMessage as TSimpleMessage;
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                let schema = TSimpleMessage::default();
+                schema.packed_doubles.write_exact(&mut buf, &doubles);
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+        group.bench_function(format!("prost_double_{name}"), |b| {
+            let msg = prost_proto::SimpleMessage {
+                packed_doubles: doubles.clone(),
+                ..Default::default()
+            };
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                msg.encode(&mut buf).unwrap();
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+
+        // --- packed fixed32 ---
+        group.bench_function(format!("tacky_fixed32_{name}"), |b| {
+            use tacky_proto::example::SimpleMessage as TSimpleMessage;
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                let schema = TSimpleMessage::default();
+                schema.packed_fixed32.write_exact(&mut buf, &fixed32s);
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+        group.bench_function(format!("prost_fixed32_{name}"), |b| {
+            let msg = prost_proto::SimpleMessage {
+                packed_fixed32: fixed32s.clone(),
+                ..Default::default()
+            };
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                msg.encode(&mut buf).unwrap();
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+
+        // --- packed fixed64 ---
+        group.bench_function(format!("tacky_fixed64_{name}"), |b| {
+            use tacky_proto::example::SimpleMessage as TSimpleMessage;
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                let schema = TSimpleMessage::default();
+                schema.packed_fixed64.write_exact(&mut buf, &fixed64s);
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+        group.bench_function(format!("prost_fixed64_{name}"), |b| {
+            let msg = prost_proto::SimpleMessage {
+                packed_fixed64: fixed64s.clone(),
+                ..Default::default()
+            };
+            let mut buf = Vec::with_capacity(4096);
+            b.iter(|| {
+                msg.encode(&mut buf).unwrap();
+                black_box(buf.as_slice());
+                buf.clear();
+            });
+        });
+    }
+    group.finish();
+}
+
+// Need the generated proto for benchmarks
+#[allow(dead_code)]
+mod tacky_proto {
+    include!(concat!(env!("OUT_DIR"), "/simple.rs"));
+}
+#[allow(dead_code)]
+mod prost_proto {
+    include!(concat!(env!("OUT_DIR"), "/example.rs"));
+}
+
+criterion_group!(benches, bench_packed_vs_prost,);
+criterion_main!(benches);

--- a/testing/protos/simple_message.proto
+++ b/testing/protos/simple_message.proto
@@ -20,6 +20,8 @@ message SimpleMessage {
     repeated fixed64 packed_fixed64 = 15 [packed=true];
     repeated sfixed32 packed_sfixed32 = 16 [packed=true];
     repeated sfixed64 packed_sfixed64 = 17 [packed=true];
+    repeated int32 repeated_ints = 18;
+    repeated float repeated_floats = 19;
 }
 
 

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -61,6 +61,8 @@ mod tests {
                 packed_fixed64: schema.packed_fixed64.write(&mut buf, &packed_fixed64),
                 packed_sfixed32: schema.packed_sfixed32.write(&mut buf, &packed_sfixed32),
                 packed_sfixed64: schema.packed_sfixed64.write(&mut buf, &packed_sfixed64),
+                repeated_ints: schema.repeated_ints.write(&mut buf, Vec::<i32>::new()),
+                repeated_floats: schema.repeated_floats.write(&mut buf, Vec::<f32>::new()),
             };
             buf
         };
@@ -88,6 +90,8 @@ mod tests {
                 packed_fixed64: packed_fixed64.to_vec(),
                 packed_sfixed32: packed_sfixed32.to_vec(),
                 packed_sfixed64: packed_sfixed64.to_vec(),
+                repeated_ints: vec![],
+                repeated_floats: vec![],
             }
         };
 
@@ -188,6 +192,8 @@ mod tests {
                                 packed_fixed64: scm.packed_fixed64.write(buf, Vec::<u64>::new()),
                                 packed_sfixed32: scm.packed_sfixed32.write(buf, Vec::<i32>::new()),
                                 packed_sfixed64: scm.packed_sfixed64.write(buf, Vec::<i64>::new()),
+                                repeated_ints: scm.repeated_ints.write(buf, Vec::<i32>::new()),
+                                repeated_floats: scm.repeated_floats.write(buf, Vec::<f32>::new()),
                             };
                         });
                     }
@@ -227,6 +233,8 @@ mod tests {
                             packed_fixed64: vec![],
                             packed_sfixed32: vec![],
                             packed_sfixed64: vec![],
+                            repeated_ints: vec![],
+                            repeated_floats: vec![],
                         })
                     }
                     v
@@ -268,6 +276,8 @@ mod tests {
             packed_fixed64: schema.packed_fixed64.write(&mut buf, &[999u64]),
             packed_sfixed32: schema.packed_sfixed32.write(&mut buf, &[-1i32]),
             packed_sfixed64: schema.packed_sfixed64.write(&mut buf, &[-100i64]),
+            repeated_ints: schema.repeated_ints.write(&mut buf, Vec::<i32>::new()),
+            repeated_floats: schema.repeated_floats.write(&mut buf, Vec::<f32>::new()),
         };
 
         // Decode with field enum
@@ -325,6 +335,8 @@ mod tests {
                 SimpleMessageField::PackedSfixed64(iter) => {
                     sfixed64s.extend(iter.map(|r| r.unwrap()));
                 }
+                SimpleMessageField::RepeatedInts(_) => {}
+                SimpleMessageField::RepeatedFloats(_) => {}
             }
         }
 
@@ -464,6 +476,8 @@ mod tests {
                     packed_fixed64: scm.packed_fixed64.write(buf, Vec::<u64>::new()),
                     packed_sfixed32: scm.packed_sfixed32.write(buf, Vec::<i32>::new()),
                     packed_sfixed64: scm.packed_sfixed64.write(buf, Vec::<i64>::new()),
+                    repeated_ints: scm.repeated_ints.write(buf, Vec::<i32>::new()),
+                    repeated_floats: scm.repeated_floats.write(buf, Vec::<f32>::new()),
                 };
             }),
         };
@@ -578,6 +592,8 @@ mod tests {
             packed_fixed64: scm.packed_fixed64.write(&mut buf, &fixed64),
             packed_sfixed32: scm.packed_sfixed32.write(&mut buf, &sfixed32),
             packed_sfixed64: scm.packed_sfixed64.write(&mut buf, &sfixed64),
+            repeated_ints: scm.repeated_ints.write(&mut buf, Vec::<i32>::new()),
+            repeated_floats: scm.repeated_floats.write(&mut buf, Vec::<f32>::new()),
         };
 
         // Verify prost can decode it


### PR DESCRIPTION
small fixes and cleanup, but also a round of microoptimizations across the board, Tacky is around twice as fast as prost in real use.
version bump because Tack now is purely a length manager, the tag is handled separately.
